### PR TITLE
Added new actions and fixed data ingestion playbook for Qradar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# connector-qradar
+#### What's new in 1.6.0
+
+- New actions:
+    - Get assets properties: Get a list of available asset property types that can be used with assets update operation
+    - Get assets: Get a list of available assets
+    - Update asset: Update one or multiple attributes of a specific asset defined by Asset ID
+    - Get cases: Get a list of Qradar cases
+    - Create case: Create a new case on Qradar
+    - Get reference tables: Get a list of Reference Tables
+    - Get table elements: Get records details of a reference table defined by name
+    - Add table element: Add or update an element in a reference table
+    - Delete table element: Delete element from a reference table
+    - Delete reference table: Delete a Reference Table or Purge its content

--- a/qradar/connector.py
+++ b/qradar/connector.py
@@ -14,6 +14,7 @@ class qradar(Connector):
     def execute(self, config, operation, params, **kwargs):
         logger.debug('execute(): Input is %s' % operations.get(operation))
         try:
+            params.update({'operation':operation})
             operation = operations.get(operation)
         except Exception:
             return ['messagePROBLEM']

--- a/qradar/funcs.py
+++ b/qradar/funcs.py
@@ -130,7 +130,19 @@ def get_notes(config, params, *args, **kwargs):
     offense_id = params['offense_id']
     qradar_connection = QradarConnection(**config)
     return qradar_connection.getNote(offense_id)
+#1.6.0
 
+def get_record(config, params, *args, **kwargs):
+    qradar_connection = QradarConnection(**config)
+    return qradar_connection.get_record(params)
+
+def update_record(config, params, *args, **kwargs):
+    qradar_connection = QradarConnection(**config)
+    return qradar_connection.update_record(params)
+
+def delete_record(config, params, *args, **kwargs):
+    qradar_connection = QradarConnection(**config)
+    return qradar_connection.delete_record(params)
 
 operations = {
     'get_offenses': get_offenses,
@@ -144,5 +156,15 @@ operations = {
     'get_offense_type': get_offense_type,
     'handle_reference_set_value': handle_reference_set_value,
     'add_notes': add_notes,
-    'get_notes': get_notes
+    'get_notes': get_notes,
+    'get_assets_properties':get_record,
+    'get_assets': get_record,
+    'update_asset': update_record,
+    'get_cases': get_record,
+    'create_case': update_record,
+    'get_reference_tables':get_record,
+    'delete_reference_table': delete_record,
+    'get_table_elements': get_record,
+    'add_table_element': update_record,
+    'delete_table_element': delete_record
 }

--- a/qradar/info.json
+++ b/qradar/info.json
@@ -1,10 +1,10 @@
 {
   "name": "qradar",
   "label": "IBM QRadar",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "IBM QRadar is an enterprise security information and event management (SIEM) product. Fortinet FortiSOSR connector for IBM QRadar allows user to invoke QRadar API, perform Ariel Queries and operations like Get Offense,related events,update and close offenses.",
   "publisher": "Fortinet",
-  "cs_approved": true,
+  "cs_approved": false,
   "cs_compatible": true,
   "category": "Analytics and SIEM",
   "icon_small_name": "small.png",
@@ -13,7 +13,7 @@
   "ingestion_modes": [
     "scheduled"
   ],
-  "help_online": "https://docs.fortinet.com/document/fortisoar/1.5.1/ibm-qradar/319/ibm-qradar-v1-5-1",
+  "help_online": "https://docs.fortinet.com/document/fortisoar/1.6.0/ibm-qradar/319/ibm-qradar-v1-6-0",
   "configuration": {
     "fields": [
       {
@@ -675,6 +675,565 @@
               }
             ]
           }
+        }
+      ]
+    },
+    {
+      "operation": "get_assets_properties",
+      "title": "Get Assets Properties",
+      "description": "Get a list of available asset property types that can be used with assets update operation.",
+      "category": "enrichment",
+      "annotation": "get_assets_properties",
+      "output_schema": [
+    {
+        "data_type":"",
+        "display":"",
+        "custom":"",
+        "name":"",
+        "id":"",
+        "state":""
+    }
+],
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Maximum Number of Attributes to return",
+          "description": "Maximum Number of attributes to return from QRadar.",
+          "tooltip": "Maximum Number of attributes to return from QRadar.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "integer",
+          "name": "max_results",
+          "value": 100
+        }
+      ]
+    },
+    {
+      "operation": "get_assets",
+      "title": "Get Assets",
+      "description": "Get a list of available assets",
+      "category": "enrichment",
+      "annotation": "get_assets",
+      "output_schema": [
+   {
+      "vulnerability_count":"",
+      "interfaces":[
+         {
+            "mac_address":"",
+            "last_seen_profiler":"",
+            "created":"",
+            "last_seen_scanner":"",
+            "first_seen_scanner":"",
+            "ip_addresses":[
+               {
+                  "last_seen_profiler":"",
+                  "created":"",
+                  "last_seen_scanner":"",
+                  "first_seen_scanner":"",
+                  "network_id":"",
+                  "id":"",
+                  "type":"",
+                  "first_seen_profiler":"",
+                  "value":""
+               }
+            ],
+            "id":"",
+            "first_seen_profiler":""
+         }
+      ],
+      "risk_score_sum":"",
+      "hostnames":"",
+      "id":"",
+      "users":"",
+      "domain_id":"",
+      "properties":[
+         {
+            "last_reported":"",
+            "name":"",
+            "type_id":"",
+            "id":"",
+            "last_reported_by":"",
+            "value":""
+         }
+      ],
+      "products":""
+   }
+],
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Filter",
+          "description": "Filter assets to return by any asset property",
+          "tooltip": "Filter assets to return by any asset property",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "filter_string",
+          "placeholder": "field_one = 'some_string' and field_two > 42 or not field_three in (1, 2, 3)",
+          "value": ""
+        },
+        {
+          "title": "Maximum Number of Assets to return",
+          "description": "Maximum Number of Assets to return from QRadar.",
+          "tooltip": "Maximum Number of Assets to return from QRadar.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "integer",
+          "name": "max_results",
+          "value": 100
+        }
+      ]
+    },
+    {
+      "operation": "update_asset",
+      "title": "Update Asset",
+      "description": "Update one or multiple attributes of a specific asset defined by Asset ID",
+      "category": "enrichment",
+      "annotation": "update_asset",
+      "output_schema": "",
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Asset ID",
+          "description": "ID of the asset to update",
+          "tooltip": "ID of the asset to update",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "path.asset_id",
+          "placeholder": "2001",
+          "value": ""
+        },
+        {
+          "title": "Asset Properties",
+          "description": "JSON dictionary with the properties to update",
+          "tooltip": "JSON dictionary with the properties values to update",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "json",
+          "name": "body.asset",
+          "placeholder": "{'properties':[{'type_id':1001,'value':'felixrobotron'},{'type_id':1002,'value':'felix.robot.terminus'}]}",
+          "value": ""
+        },
+        {
+          "title": "Content Type",
+          "description": "System field",
+          "tooltip": "System field, cannot be edited",
+          "required": false,
+          "editable": false,
+          "visible": true,
+          "type": "text",
+          "name": "content_type",
+          "value": "text/plain"
+        }
+      ]
+    },
+    {
+      "operation": "get_cases",
+      "title": "Get Cases",
+      "description": "Get a list of Qradar cases",
+      "category": "enrichment",
+      "annotation": "get_cases",
+      "output_schema": [
+   {
+      "assigned_to":[
+
+      ],
+      "id":"",
+      "name":""
+   }
+],
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Filter",
+          "description": "Filter cases to return by any case property",
+          "tooltip": "Filter cases to return by any case property",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "filter_string",
+          "placeholder": "field_one = 'some_string' and field_two > 42 or not field_three in (1, 2, 3)",
+          "value": ""
+        },
+        {
+          "title": "Maximum Number of Cases to return",
+          "description": "Maximum Number of Cases to return from QRadar.",
+          "tooltip": "Maximum Number of Cases to return from QRadar.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "integer",
+          "name": "max_results",
+          "value": 100
+        }
+      ]
+    },
+    {
+      "operation": "create_case",
+      "title": "Create Case",
+      "description": "Create a new case on Qradar",
+      "category": "enrichment",
+      "annotation": "create_case",
+      "output_schema": {
+   "case_id":"",
+   "name":"",
+   "id":"",
+   "state":"",
+   "assigned_to":[
+
+   ]
+},
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Case Properties",
+          "description": "JSON dictionary with the properties of the case to create",
+          "tooltip": "JSON dictionary with the properties of the case to create",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "json",
+          "name": "body.case",
+          "placeholder": "{'assigned_to':['admin'],'name':'case1'}",
+          "value": ""
+        },
+        {
+          "title": "Content Type",
+          "description": "System field",
+          "tooltip": "System field, cannot be edited",
+          "required": false,
+          "editable": false,
+          "visible": true,
+          "type": "text",
+          "name": "content_type",
+          "value": "application/json"
+        }
+      ]
+    },
+    {
+      "operation": "get_reference_tables",
+      "title": "Get Reference Tables",
+      "description": "Get a list of Reference Tables",
+      "category": "enrichment",
+      "annotation": "get_reference_tables",
+      "output_schema": [
+   {
+      "timeout_type":"",
+      "number_of_elements":"",
+      "creation_time":"",
+      "name":"",
+      "key_name_types":{
+         "port":"",
+         "source_ip":"",
+         "timestamp":""
+      },
+      "element_type":""
+   }
+],
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Filter",
+          "description": "Filter reference tables to return by any table property",
+          "tooltip": "Filter reference tables to return by any table property",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "filter_string",
+          "placeholder": "field_one = 'some_string' and field_two > 42 or not field_three in (1, 2, 3)",
+          "value": ""
+        },
+        {
+          "title": "Maximum Number of Reference Tables to return",
+          "description": "Maximum Number of Reference Tables to return from QRadar.",
+          "tooltip": "Maximum Number of Reference Tables to return from QRadar.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "integer",
+          "name": "max_results",
+          "value": 100
+        }
+      ]
+    },
+    {
+      "operation": "delete_reference_table",
+      "title": "Delete/Purge Reference Table",
+      "description": "Delete a Reference Table or Purge its content",
+      "category": "enrichment",
+      "annotation": "delete_reference_table",
+      "output_schema": {
+   "created_by":"",
+   "created":"",
+   "name":"",
+   "modified":"",
+   "started":"",
+   "completed":"",
+   "id":"",
+   "message":"",
+   "status":""
+},
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Reference Table Name",
+          "description": "The name of the reference table to delete or purge",
+          "tooltip": "The name of the reference table to delete or purge",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "path.name",
+          "placeholder": "",
+          "value": ""
+        },
+        {
+          "title": "Purge Table",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "select",
+          "description": "Purges the Reference Table instead of deleting it",
+          "tooltip": "Purges the Reference Table instead of deleting it",
+          "options": ["true", "false"],
+          "name": "query.purge_only",
+          "value": "true"
+
+        }
+      ]
+    },
+    {
+      "operation": "get_table_elements",
+      "title": "Get Table Elements",
+      "description": "Get records details of a reference table defined by name",
+      "category": "enrichment",
+      "annotation": "get_table_elements",
+      "output_schema":{
+   "timeout_type":"",
+   "number_of_elements":"",
+   "data":{
+      "outer_key":{
+         "inner_key":{
+            "last_seen":"",
+            "first_seen":"",
+            "source":"",
+            "value":""
+         }
+      }
+   },
+   "creation_time":"",
+   "name":"",
+   "key_name_types":"",
+   "element_type":""
+},
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Reference Table Name",
+          "description": "Name of the reference table to fetch",
+          "tooltip": "Name of the reference table to fetch",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "path.name",
+          "placeholder":"field_one = 'some_string' and field_two > 42 or not field_three in (1, 2, 3)",
+          "value": ""
+        },
+        {
+          "title": "Maximum Number of Reference Tables to return",
+          "description": "Maximum Number of Reference Tables to return from QRadar.",
+          "tooltip": "Maximum Number of Reference Tables to return from QRadar.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "integer",
+          "name": "max_results",
+          "value": 100
+        }
+      ]
+    },
+    {
+      "operation": "add_table_element",
+      "title": "Add/Update Table Element",
+      "description": "Add or update an element in a reference table",
+      "category": "enrichment",
+      "annotation": "add_table_element",
+      "output_schema": {
+   "timeout_type":"",
+   "number_of_elements":"",
+   "creation_time":"",
+   "name":"",
+   "key_name_types":"",
+   "element_type":""
+},
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Reference Table Name",
+          "description": "The name of the reference table to add or update an element in",
+          "tooltip": "The name of the reference table to add or update an element in",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "path.name",
+          "placeholder": "",
+          "value": ""
+        },
+        {
+          "title": "Outer Key",
+          "description": "The outer key for the element  to add or update",
+          "tooltip": "The outer key for the element  to add or update",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "query.outer_key",
+          "placeholder": "",
+          "value": ""
+        },
+        {
+          "title": "Inner Key",
+          "description": "The inner key for the element to add or update",
+          "tooltip": "The inner key for the element to add or update",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "query.inner_key",
+          "placeholder": "",
+          "value": ""
+        },
+        {
+          "title": "value",
+          "description": "The value to add or update in the reference table. Note: Date values must be represented in Unix Epoch milliseconds.",
+          "tooltip": "The value to add or update in the reference table. Note: Date values must be represented in Unix Epoch milliseconds, ex: 1671706076483",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "query.value",
+          "placeholder": "",
+          "value": ""
+        },
+        {
+          "title": "Domain ID",
+          "description": "Sets the domain id for the value to be specified. If null, the shared domain will be used.",
+          "tooltip": "For MSSP setups, it sets the domain id for the value to be specified. If null, the shared domain will be used.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "query.domain_id",
+          "value": ""
+        },
+        {
+          "title": "Element Source",
+          "description": "An indication of where the data originated. The default value is 'FortiSOAR'",
+          "tooltip": "An indication of where the data originated. The default value is 'FortiSOAR'",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "query.source",
+          "value": "FortiSOAR"
+        }
+      ]
+    },
+    {
+      "operation": "delete_table_element",
+      "title": "Delete Table Element",
+      "description": "Delete element from a reference table",
+      "category": "enrichment",
+      "annotation": "delete_table_element",
+      "output_schema": {
+   "timeout_type":"",
+   "number_of_elements":"",
+   "creation_time":"",
+   "name":"",
+   "key_name_types":"",
+   "element_type":""
+},
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Reference Table Name",
+          "description": "The name of the reference table to remove element from",
+          "tooltip": "The name of the reference table to remove element from",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "path.name",
+          "placeholder": "",
+          "value": ""
+        },
+        {
+          "title": "Outer Key",
+          "description": "The outer key of the element to delete",
+          "tooltip": "The outer key of element to delete",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "path.outer_key",
+          "placeholder": "",
+          "value": ""
+        },
+        {
+          "title": "Inner Key",
+          "description": "The inner key of the element to delete",
+          "tooltip": "The inner key of the element to delete",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "path.inner_key",
+          "placeholder": "",
+          "value": ""
+        },
+        {
+          "title": "value",
+          "description": "The value of the element to delete. Note: Date values must be represented in Epoch milliseconds",
+          "tooltip": "The value of the element to delete. Note: Date values must be represented in Epoch milliseconds",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "query.value",
+          "placeholder": "",
+          "value": ""
+        },
+        {
+          "title": "Domain ID",
+          "description": "Sets the domain id for the value to be specified. If null, the shared domain will be used.",
+          "tooltip": "For MSSP setups, it sets the domain id for the value to be specified. If null, the shared domain will be used.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "query.domain_id",
+          "value": ""
+        },
+        {
+          "title": "Element Source",
+          "description": "An indication of where the data originated. The default value is 'FortiSOAR'",
+          "tooltip": "An indication of where the data originated. The default value is 'FortiSOAR'",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "query.source",
+          "value": "FortiSOAR"
         }
       ]
     }

--- a/qradar/info.json
+++ b/qradar/info.json
@@ -4,7 +4,7 @@
   "version": "1.6.0",
   "description": "IBM QRadar is an enterprise security information and event management (SIEM) product. Fortinet FortiSOSR connector for IBM QRadar allows user to invoke QRadar API, perform Ariel Queries and operations like Get Offense,related events,update and close offenses.",
   "publisher": "Fortinet",
-  "cs_approved": false,
+  "cs_approved": true,
   "cs_compatible": true,
   "category": "Analytics and SIEM",
   "icon_small_name": "small.png",
@@ -13,7 +13,7 @@
   "ingestion_modes": [
     "scheduled"
   ],
-  "help_online": "https://docs.fortinet.com/document/fortisoar/1.6.0/ibm-qradar/319/ibm-qradar-v1-6-0",
+  "help_online": "",
   "configuration": {
     "fields": [
       {
@@ -42,7 +42,7 @@
         "visible": true,
         "type": "text",
         "name": "api_version",
-        "value": "6.0",
+        "value": "14.0",
         "description": "Version of the QRadar API to be used for performing automated operations."
       },
       {

--- a/qradar/info.json
+++ b/qradar/info.json
@@ -682,18 +682,18 @@
       "operation": "get_assets_properties",
       "title": "Get Assets Properties",
       "description": "Get a list of available asset property types that can be used with assets update operation.",
-      "category": "enrichment",
+      "category": "investigation",
       "annotation": "get_assets_properties",
       "output_schema": [
-    {
-        "data_type":"",
-        "display":"",
-        "custom":"",
-        "name":"",
-        "id":"",
-        "state":""
-    }
-],
+        {
+          "data_type":"",
+          "display":"",
+          "custom":"",
+          "name":"",
+          "id":"",
+          "state":""
+        }
+      ],
       "enabled": true,
       "parameters": [
         {
@@ -713,20 +713,20 @@
       "operation": "get_assets",
       "title": "Get Assets",
       "description": "Get a list of available assets",
-      "category": "enrichment",
+      "category": "investigation",
       "annotation": "get_assets",
       "output_schema": [
-   {
-      "vulnerability_count":"",
-      "interfaces":[
-         {
-            "mac_address":"",
-            "last_seen_profiler":"",
-            "created":"",
-            "last_seen_scanner":"",
-            "first_seen_scanner":"",
-            "ip_addresses":[
-               {
+        {
+          "vulnerability_count":"",
+          "interfaces":[
+            {
+              "mac_address":"",
+              "last_seen_profiler":"",
+              "created":"",
+              "last_seen_scanner":"",
+              "first_seen_scanner":"",
+              "ip_addresses":[
+                {
                   "last_seen_profiler":"",
                   "created":"",
                   "last_seen_scanner":"",
@@ -736,30 +736,30 @@
                   "type":"",
                   "first_seen_profiler":"",
                   "value":""
-               }
-            ],
-            "id":"",
-            "first_seen_profiler":""
-         }
+                }
+              ],
+              "id":"",
+              "first_seen_profiler":""
+            }
+          ],
+          "risk_score_sum":"",
+          "hostnames":"",
+          "id":"",
+          "users":"",
+          "domain_id":"",
+          "properties":[
+            {
+              "last_reported":"",
+              "name":"",
+              "type_id":"",
+              "id":"",
+              "last_reported_by":"",
+              "value":""
+            }
+          ],
+          "products":""
+        }
       ],
-      "risk_score_sum":"",
-      "hostnames":"",
-      "id":"",
-      "users":"",
-      "domain_id":"",
-      "properties":[
-         {
-            "last_reported":"",
-            "name":"",
-            "type_id":"",
-            "id":"",
-            "last_reported_by":"",
-            "value":""
-         }
-      ],
-      "products":""
-   }
-],
       "enabled": true,
       "parameters": [
         {
@@ -791,7 +791,7 @@
       "operation": "update_asset",
       "title": "Update Asset",
       "description": "Update one or multiple attributes of a specific asset defined by Asset ID",
-      "category": "enrichment",
+      "category": "investigation",
       "annotation": "update_asset",
       "output_schema": "",
       "enabled": true,
@@ -837,17 +837,15 @@
       "operation": "get_cases",
       "title": "Get Cases",
       "description": "Get a list of Qradar cases",
-      "category": "enrichment",
+      "category": "investigation",
       "annotation": "get_cases",
       "output_schema": [
-   {
-      "assigned_to":[
-
+        {
+          "assigned_to":[],
+          "id":"",
+          "name":""
+        }
       ],
-      "id":"",
-      "name":""
-   }
-],
       "enabled": true,
       "parameters": [
         {
@@ -879,17 +877,15 @@
       "operation": "create_case",
       "title": "Create Case",
       "description": "Create a new case on Qradar",
-      "category": "enrichment",
+      "category": "investigation",
       "annotation": "create_case",
       "output_schema": {
-   "case_id":"",
-   "name":"",
-   "id":"",
-   "state":"",
-   "assigned_to":[
-
-   ]
-},
+         "case_id":"",
+         "name":"",
+         "id":"",
+         "state":"",
+         "assigned_to":[]
+      },
       "enabled": true,
       "parameters": [
         {
@@ -921,22 +917,22 @@
       "operation": "get_reference_tables",
       "title": "Get Reference Tables",
       "description": "Get a list of Reference Tables",
-      "category": "enrichment",
+      "category": "investigation",
       "annotation": "get_reference_tables",
       "output_schema": [
-   {
-      "timeout_type":"",
-      "number_of_elements":"",
-      "creation_time":"",
-      "name":"",
-      "key_name_types":{
-         "port":"",
-         "source_ip":"",
-         "timestamp":""
-      },
-      "element_type":""
-   }
-],
+         {
+            "timeout_type":"",
+            "number_of_elements":"",
+            "creation_time":"",
+            "name":"",
+            "key_name_types":{
+               "port":"",
+               "source_ip":"",
+               "timestamp":""
+            },
+            "element_type":""
+         }
+      ],
       "enabled": true,
       "parameters": [
         {
@@ -968,19 +964,19 @@
       "operation": "delete_reference_table",
       "title": "Delete/Purge Reference Table",
       "description": "Delete a Reference Table or Purge its content",
-      "category": "enrichment",
+      "category": "investigation",
       "annotation": "delete_reference_table",
       "output_schema": {
-   "created_by":"",
-   "created":"",
-   "name":"",
-   "modified":"",
-   "started":"",
-   "completed":"",
-   "id":"",
-   "message":"",
-   "status":""
-},
+         "created_by":"",
+         "created":"",
+         "name":"",
+         "modified":"",
+         "started":"",
+         "completed":"",
+         "id":"",
+         "message":"",
+         "status":""
+      },
       "enabled": true,
       "parameters": [
         {
@@ -992,7 +988,6 @@
           "visible": true,
           "type": "text",
           "name": "path.name",
-          "placeholder": "",
           "value": ""
         },
         {
@@ -1014,26 +1009,26 @@
       "operation": "get_table_elements",
       "title": "Get Table Elements",
       "description": "Get records details of a reference table defined by name",
-      "category": "enrichment",
+      "category": "investigation",
       "annotation": "get_table_elements",
       "output_schema":{
-   "timeout_type":"",
-   "number_of_elements":"",
-   "data":{
-      "outer_key":{
-         "inner_key":{
-            "last_seen":"",
-            "first_seen":"",
-            "source":"",
-            "value":""
-         }
-      }
-   },
-   "creation_time":"",
-   "name":"",
-   "key_name_types":"",
-   "element_type":""
-},
+         "timeout_type":"",
+         "number_of_elements":"",
+         "data":{
+            "outer_key":{
+               "inner_key":{
+                  "last_seen":"",
+                  "first_seen":"",
+                  "source":"",
+                  "value":""
+               }
+            }
+         },
+         "creation_time":"",
+         "name":"",
+         "key_name_types":"",
+         "element_type":""
+      },
       "enabled": true,
       "parameters": [
         {
@@ -1065,16 +1060,16 @@
       "operation": "add_table_element",
       "title": "Add/Update Table Element",
       "description": "Add or update an element in a reference table",
-      "category": "enrichment",
+      "category": "investigation",
       "annotation": "add_table_element",
       "output_schema": {
-   "timeout_type":"",
-   "number_of_elements":"",
-   "creation_time":"",
-   "name":"",
-   "key_name_types":"",
-   "element_type":""
-},
+         "timeout_type":"",
+         "number_of_elements":"",
+         "creation_time":"",
+         "name":"",
+         "key_name_types":"",
+         "element_type":""
+      },
       "enabled": true,
       "parameters": [
         {
@@ -1153,16 +1148,16 @@
       "operation": "delete_table_element",
       "title": "Delete Table Element",
       "description": "Delete element from a reference table",
-      "category": "enrichment",
+      "category": "investigation",
       "annotation": "delete_table_element",
       "output_schema": {
-   "timeout_type":"",
-   "number_of_elements":"",
-   "creation_time":"",
-   "name":"",
-   "key_name_types":"",
-   "element_type":""
-},
+         "timeout_type":"",
+         "number_of_elements":"",
+         "creation_time":"",
+         "name":"",
+         "key_name_types":"",
+         "element_type":""
+      },
       "enabled": true,
       "parameters": [
         {

--- a/qradar/playbooks/playbooks.json
+++ b/qradar/playbooks/playbooks.json
@@ -3,20 +3,1319 @@
   "data": [
     {
       "@type": "WorkflowCollection",
-      "name": "Sample - IBM QRadar - 1.5.1",
+      "name": "Sample - IBM QRadar - 1.6.0",
       "description": "IBM QRadar is an enterprise security information and event management (SIEM) product. Fortinet FortiSOAR Connector for IBM QRadar allows user to invoke QRadar API, perform Ariel Queries and operations like Get Offense,related events,update and close offenses.",
       "visible": true,
       "image": null,
-      "uuid": "d129e8bf-32f1-410d-8807-343693acde71",
-      "id": 488,
-      "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-      "createDate": 1657270455.808023,
-      "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-      "modifyDate": 1657270455.808023,
+      "uuid": "5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+      "id": 154,
       "deletedAt": null,
       "importedBy": [],
       "recordTags": [],
       "workflows": [
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Create Note",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Create a note on specified offense id on QRadar.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/6317afbc-ea91-4325-bd9a-528670d6369b",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "a172d44d-5fd1-4f79-bd84-570a06d65a70",
+                "title": "IBM QRadar: Create Note",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "200",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "6317afbc-ea91-4325-bd9a-528670d6369b"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Create Note",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "offense_id": "286",
+                  "closure_note": "Add note from FortiSOAR."
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "add_notes",
+                "operationTitle": "Create Note",
+                "step_variables": {
+                  "output_data": "{{vars.result.data}}"
+                }
+              },
+              "status": null,
+              "top": "114",
+              "left": "200",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "b4aa4e20-9792-4f1b-906d-3bb3b7bc0ef3"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Get Reasons",
+              "targetStep": "/api/3/workflow_steps/b4aa4e20-9792-4f1b-906d-3bb3b7bc0ef3",
+              "sourceStep": "/api/3/workflow_steps/6317afbc-ea91-4325-bd9a-528670d6369b",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "aa99a995-9740-402a-a09f-512f20735495"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "0313ec68-1f43-4444-9bd6-bd629528346c",
+          "id": 2332,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "IBM QRadar > Post Create Alert > Fetch Events",
+          "aliasName": null,
+          "tag": "#qradar #dataingestion",
+          "description": "Fetch events, source and destination ip address of an offense.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [
+            "qradar_timezone",
+            "qradar_event_limit",
+            "alertRecord"
+          ],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/70333c17-e1cf-4dbd-995d-536751620ef3",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Configuration",
+              "description": null,
+              "arguments": {
+                "current_time": "{{arrow.now(vars.input.params['qradar_timezone']).format('YYYY-MM-DD HH:mm:ss')}}",
+                "event_query_params": "starttime,sourceip,destinationip,username,QIDNAME(qid) as 'Event_Name',CATEGORYNAME(category) AS 'Category_Name',LOGSOURCENAME(logsourceid) as 'Log_Source'",
+                "event_record_limit": "{% if vars.input.params['qradar_event_limit']%}{{vars.input.params['qradar_event_limit']}}{% else %}50{% endif %}",
+                "offense_start_time": "{{arrow.get((vars.alertSourceData.offense_data.start_time | int )/1000).to(vars.input.params['qradar_timezone']).format('YYYY-MM-DD HH:mm:ss')}}"
+              },
+              "status": null,
+              "top": "200",
+              "left": "340",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "2a4a85de-fba7-49ac-b8a0-de4ed6bdff09"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Fetch Events For an Offense",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "search_string": "SELECT  {{vars.event_query_params}} FROM EVENTS WHERE INOFFENSE({{vars.alertSourceData.offense_data['id']}}) ORDER BY starttime DESC LIMIT {{vars.event_record_limit}} START  '{{vars.offense_start_time}}' STOP '{{vars.current_time}}'"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "query_qradar",
+                "operationTitle": "Make an Ariel Query to QRadar",
+                "step_variables": {
+                  "offense_details": "{\n\"offense_data\": {{vars.alertSourceData.offense_data}},\n\"events_data\": {{vars.result.data.events}}\n}"
+                }
+              },
+              "status": null,
+              "top": "271",
+              "left": "649",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "38ea4380-9b4f-487f-9642-74b4bba15716"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Update Alert",
+              "description": null,
+              "arguments": {
+                "resource": {
+                  "sourcedata": "{{vars.offense_details | toJSON }}"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "{{vars.input.params.alertRecord['@id']}}",
+                "__recommend": [],
+                "collectionType": "/api/3/alerts",
+                "fieldOperation": {
+                  "recordTags": "Append"
+                },
+                "step_variables": []
+              },
+              "status": null,
+              "top": "353",
+              "left": "840",
+              "stepType": "/api/3/workflow_step_types/b593663d-7d13-40ce-a3a3-96dece928722",
+              "group": null,
+              "uuid": "6a79c6f2-303d-4563-8856-a2f599c7af5a"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "step_variables": {
+                  "input": {
+                    "params": []
+                  }
+                }
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+              "group": null,
+              "uuid": "70333c17-e1cf-4dbd-995d-536751620ef3"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Set Source Data",
+              "description": null,
+              "arguments": {
+                "alertSourceData": "{{vars.input.params.alertRecord.sourcedata | from_json}}"
+              },
+              "status": null,
+              "top": "111",
+              "left": "189",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "bcd95b7c-6a53-41df-8807-a34728d2958c"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Set Source Data",
+              "targetStep": "/api/3/workflow_steps/bcd95b7c-6a53-41df-8807-a34728d2958c",
+              "sourceStep": "/api/3/workflow_steps/70333c17-e1cf-4dbd-995d-536751620ef3",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "3366528e-475a-4ed6-8df0-52d89146bb46"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Set Source Data -> Configuration",
+              "targetStep": "/api/3/workflow_steps/2a4a85de-fba7-49ac-b8a0-de4ed6bdff09",
+              "sourceStep": "/api/3/workflow_steps/bcd95b7c-6a53-41df-8807-a34728d2958c",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "67eefbaa-ad23-463a-bc52-25aef8950168"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Configuration -> Fetch Events For an Offense",
+              "targetStep": "/api/3/workflow_steps/38ea4380-9b4f-487f-9642-74b4bba15716",
+              "sourceStep": "/api/3/workflow_steps/2a4a85de-fba7-49ac-b8a0-de4ed6bdff09",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "7fcc1286-d0e5-4906-afa3-0f3822857eaf"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Fetch Events For an Offense -> Update Alert",
+              "targetStep": "/api/3/workflow_steps/6a79c6f2-303d-4563-8856-a2f599c7af5a",
+              "sourceStep": "/api/3/workflow_steps/38ea4380-9b4f-487f-9642-74b4bba15716",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "a91b7942-6827-4159-8ef0-d95c9da4294b"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "121ddc91-e89f-47ca-acdd-f1adad50ef31",
+          "id": 2339,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "dataingestion",
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Update Asset",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Update one or multiple attributes of a specific asset defined by Asset ID",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672638138,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/d86b58af-8bce-4f35-8470-98b809baf588",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "e8e9d4c4-e121-45bd-a74e-4c6f2c537fac",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "d86b58af-8bce-4f35-8470-98b809baf588"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Update Assets",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "e524c682-01c1-416b-94bb-40aa2f2e6f55",
+                "params": {
+                  "body.asset": "{\r\n    \"properties\": [\r\n        {\r\n            \"type_id\": 1001,\r\n            \"value\": \"felixrobotron\"\r\n        },\r\n        {\r\n            \"type_id\": 1002,\r\n            \"value\": \"felix.robot.terminus\"\r\n        }\r\n    ]\r\n}",
+                  "path.asset_id": "1001"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "update_asset",
+                "operationTitle": "Update Assets",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "ff4fb8df-a993-45b8-b7e7-339cf64ff3df"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Destination IP Addresses",
+              "targetStep": "/api/3/workflow_steps/ff4fb8df-a993-45b8-b7e7-339cf64ff3df",
+              "sourceStep": "/api/3/workflow_steps/d86b58af-8bce-4f35-8470-98b809baf588",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "71ea43fa-cb99-47b0-9190-456397d2219f"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "175ab7bd-4310-4216-8bf3-456d9165b4b2",
+          "id": 2346,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Events Related to an Offense",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Get Events Related to an Offense",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/380914f5-79ef-4b66-8adb-4f5680923070",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Events Related to an Offense",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "offense_id": "41",
+                  "start_time": "2019-06-03T18:30:00.000Z",
+                  "max_results": 100,
+                  "last_updated_time": "2019-07-02T18:30:00.000Z"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_events_related_to_offense",
+                "operationTitle": "Get Events Related to an Offense",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "107",
+              "left": "200",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "2216b6e2-f589-4d04-a497-c874885373b4"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "1ac8022b-0540-4b59-b965-f6ef5415341c",
+                "title": "IBM QRadar: Get Events Related to an Offense",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "380914f5-79ef-4b66-8adb-4f5680923070"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Events Related to an Offense",
+              "targetStep": "/api/3/workflow_steps/2216b6e2-f589-4d04-a497-c874885373b4",
+              "sourceStep": "/api/3/workflow_steps/380914f5-79ef-4b66-8adb-4f5680923070",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "75b7637a-09e9-434b-a737-3fc58395fd4f"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "19d030f6-0e4d-4dc4-ab92-34475a93ef2e",
+          "id": 2334,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Close QRadar Offenses",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "This playbook demonstrate Get Offense Closing Reasons Operation.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/318a6aec-68d7-4642-9892-428203d0c8c2",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Do Nothing",
+              "description": null,
+              "arguments": {
+                "params": [],
+                "version": "2.4.1",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "475",
+              "left": "47",
+              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+              "group": null,
+              "uuid": "2c7b0274-abf3-468e-ad7f-304d5fd7d56c"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "0a5f45c5-4811-49a3-a964-ff12279a44a2",
+                "title": "IBM QRadar: Close QRadar Offense",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": false,
+                "singleRecordExecution": true
+              },
+              "status": null,
+              "top": "20",
+              "left": "200",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "318a6aec-68d7-4642-9892-428203d0c8c2"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Check Reason Ids",
+              "description": null,
+              "arguments": {
+                "reason_id_list": "{{ vars.result.data| selectattr(\"text\", \"equalto\", \"Policy Violation\")|list }}"
+              },
+              "status": null,
+              "top": "234",
+              "left": "200",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "7265e631-13c5-4d7c-8cc3-47ab10082adf"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Found a matching reason",
+              "description": null,
+              "arguments": {
+                "conditions": [
+                  {
+                    "step_iri": "/api/3/workflow_steps/f884985d-0498-4d33-819b-a6ef8cc5c11a",
+                    "condition": "{{ vars.reason_id_list is defined and vars.reason_id_list|length > 0 }}"
+                  },
+                  {
+                    "default": true,
+                    "step_iri": "/api/3/workflow_steps/2c7b0274-abf3-468e-ad7f-304d5fd7d56c"
+                  }
+                ]
+              },
+              "status": null,
+              "top": "340",
+              "left": "200",
+              "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+              "group": null,
+              "uuid": "a788dbd8-7b24-4cd5-83be-404cba4cf4c4"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Reasons",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": [],
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_closing_reasons",
+                "operationTitle": "Get Offense Closing Reasons",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "113",
+              "left": "200",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "f267008d-598c-417f-be94-98cd3a0fc42f"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Close Off",
+              "description": null,
+              "arguments": {
+                "for_each": {
+                  "item": "{{ vars.request.data.records }}",
+                  "condition": ""
+                },
+                "arguments": {
+                  "reasonID": "{{vars.reason_id}}",
+                  "offenseID": "{{vars.item}}"
+                },
+                "step_variables": [],
+                "workflowReference": "/api/3/workflows/a24ecd78-2b91-4a05-88f0-657922cad26d"
+              },
+              "status": null,
+              "top": "614",
+              "left": "420",
+              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+              "group": null,
+              "uuid": "f2f5de49-3062-46f3-bcd5-24048c9abeb1"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Set Reason Id",
+              "description": null,
+              "arguments": {
+                "reason_id": "{{ vars.reason_id_list [0]['id'] }}"
+              },
+              "status": null,
+              "top": "480",
+              "left": "380",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "f884985d-0498-4d33-819b-a6ef8cc5c11a"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Set Reason Id -> Close Off",
+              "targetStep": "/api/3/workflow_steps/f2f5de49-3062-46f3-bcd5-24048c9abeb1",
+              "sourceStep": "/api/3/workflow_steps/f884985d-0498-4d33-819b-a6ef8cc5c11a",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "970b507e-c743-482c-a5dd-41e1e007473d"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Found a matching reason -> yay",
+              "targetStep": "/api/3/workflow_steps/f884985d-0498-4d33-819b-a6ef8cc5c11a",
+              "sourceStep": "/api/3/workflow_steps/a788dbd8-7b24-4cd5-83be-404cba4cf4c4",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "3335ae45-dc9b-4496-a415-504134626dcd"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Found a matching reason -> Do Nothing",
+              "targetStep": "/api/3/workflow_steps/2c7b0274-abf3-468e-ad7f-304d5fd7d56c",
+              "sourceStep": "/api/3/workflow_steps/a788dbd8-7b24-4cd5-83be-404cba4cf4c4",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "2707961f-b1e7-430a-9a54-ae783e1520ed"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Set Reason Id -> Found a matching reason",
+              "targetStep": "/api/3/workflow_steps/a788dbd8-7b24-4cd5-83be-404cba4cf4c4",
+              "sourceStep": "/api/3/workflow_steps/7265e631-13c5-4d7c-8cc3-47ab10082adf",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "6e2efda2-d615-43b9-bfb3-6acf3ed89a69"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Get Reasons -> Check Reason Ids",
+              "targetStep": "/api/3/workflow_steps/7265e631-13c5-4d7c-8cc3-47ab10082adf",
+              "sourceStep": "/api/3/workflow_steps/f267008d-598c-417f-be94-98cd3a0fc42f",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "df18e1d6-f3cc-48c5-8d49-83b4f44d488b"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Get Reasons",
+              "targetStep": "/api/3/workflow_steps/f267008d-598c-417f-be94-98cd3a0fc42f",
+              "sourceStep": "/api/3/workflow_steps/318a6aec-68d7-4642-9892-428203d0c8c2",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "f8e912c3-5f5b-45f8-8528-d879aea1f256"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "1ba5d999-e460-4da0-8cc3-41bf5994b933",
+          "id": 2340,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "API - Push Offense From QRadar",
+          "aliasName": null,
+          "tag": "#qradar app",
+          "description": "This playbook demonstrate the QRadar App. You need have QRadar CyberSponse App installed on QRadar.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/dd6cf9e8-0006-45eb-a049-c0939fcfada8",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Offense Details",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "filter_string": "id={{ vars.request.data.Offense_ID }}"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_offenses",
+                "operationTitle": "Get Offenses from QRadar",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "160",
+              "left": "400",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "077b9eb8-1e0b-479f-b239-91fe964e2e2a"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "qradar",
+                "authentication_methods": [
+                  ""
+                ]
+              },
+              "status": null,
+              "top": "53",
+              "left": "234",
+              "stepType": "/api/3/workflow_step_types/df26c7a2-4166-4ca5-91e5-548e24c01b5f",
+              "group": null,
+              "uuid": "dd6cf9e8-0006-45eb-a049-c0939fcfada8"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Get Offense Details",
+              "targetStep": "/api/3/workflow_steps/077b9eb8-1e0b-479f-b239-91fe964e2e2a",
+              "sourceStep": "/api/3/workflow_steps/dd6cf9e8-0006-45eb-a049-c0939fcfada8",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "345e7bce-0168-44e5-b08d-9fb35389e0fc"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "247e1d99-0500-4b1e-86fc-b68433d91803",
+          "id": 2337,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar app"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Source IP Addresses",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Get Details for the given source IP Address Ids",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/f7cefae1-2d04-4bd7-a5f6-2005cd67f435",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Source IP Addresses",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "source_address_ids": "[4]"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_source_ip",
+                "operationTitle": "Get Source IP Addresses",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "df68728d-6862-4e9d-9991-aebc01626621"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "8f2ddef8-1182-4075-a612-788899512831",
+                "title": "IBM QRadar: Get Source IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "f7cefae1-2d04-4bd7-a5f6-2005cd67f435"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Source IP Addresses",
+              "targetStep": "/api/3/workflow_steps/df68728d-6862-4e9d-9991-aebc01626621",
+              "sourceStep": "/api/3/workflow_steps/f7cefae1-2d04-4bd7-a5f6-2005cd67f435",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "c2977d58-710e-4651-8ffc-284e54b31ab5"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "2841672e-327f-4522-aab7-b2d9bda9fb24",
+          "id": 2333,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Manipulate Reference Set Content",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Add, retrieve or delete the content from specified reference set",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/39cd3095-b2e8-4bf6-9508-176975caf8a4",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "d4eba327-9276-45ca-b2e9-7d54b897e542",
+                "title": "IBM QRadar: Manipulate Reference Set Content",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "80",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "39cd3095-b2e8-4bf6-9508-176975caf8a4"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Manipulate Reference Set Content",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "name": "FortiSOAR RFC",
+                  "method": "Retrieves Value"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "handle_reference_set_value",
+                "operationTitle": "Manipulate Reference Set Content",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "152",
+              "left": "253",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "aa49ce4a-7cef-4b68-a0ca-7a32c17c6e3a"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Manipulate Reference Set Content",
+              "targetStep": "/api/3/workflow_steps/aa49ce4a-7cef-4b68-a0ca-7a32c17c6e3a",
+              "sourceStep": "/api/3/workflow_steps/39cd3095-b2e8-4bf6-9508-176975caf8a4",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "452798b5-0a81-4772-a010-8fb7d454d9af"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "2d225858-8c37-4462-b3be-5203f919ab9c",
+          "id": 2338,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Offenses",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Get Offenses from QRadar.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/cade8843-3f49-4c8d-a539-077c262fe262",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Offenses",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "filter_string": "status=\"OPEN\""
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_offenses",
+                "operationTitle": "Get Offenses from QRadar",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "991af3ff-19d2-4cc5-a43e-df48c5efd36e"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "e3f8226f-8e07-4bca-9306-4ecf3c42681b",
+                "title": "IBM QRadar: Get Offenses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "cade8843-3f49-4c8d-a539-077c262fe262"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Get Offenses",
+              "targetStep": "/api/3/workflow_steps/991af3ff-19d2-4cc5-a43e-df48c5efd36e",
+              "sourceStep": "/api/3/workflow_steps/cade8843-3f49-4c8d-a539-077c262fe262",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "04334156-bc43-4493-894a-19c17371a0e8"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "3fb5368f-315c-48c0-942f-2f85e4e6d037",
+          "id": 2341,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Delete Reference Table",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Delete a Reference Table or Purge its content",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672638776,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/59bfd5d7-c45a-43cd-aa70-2b0f25ecead1",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "d007a236-595c-43ca-b80a-5780b61d9591",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "59bfd5d7-c45a-43cd-aa70-2b0f25ecead1"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Delete Reference Table",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "e524c682-01c1-416b-94bb-40aa2f2e6f55",
+                "params": {
+                  "path.name": "ip_whitelist",
+                  "query.purge_only": "true"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "delete_reference_table",
+                "operationTitle": "Delete/Purge Reference Table",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "f29f75e8-bd00-4127-a75d-fa3c2fae710c"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Destination IP Addresses",
+              "targetStep": "/api/3/workflow_steps/f29f75e8-bd00-4127-a75d-fa3c2fae710c",
+              "sourceStep": "/api/3/workflow_steps/59bfd5d7-c45a-43cd-aa70-2b0f25ecead1",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "6e66a107-3178-4b13-bc8c-546ac2660118"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "40b9cf4a-f628-4f59-b338-4a0ad9f1f3bf",
+          "id": 2353,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Invoke QRadar REST API",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "This playbook demonstrate Invoke QRadar API operation",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/76fa16a1-bc32-48ac-a7af-6f9e7387d988",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Invoke QRadar API",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "method": "GET",
+                  "headers": "{\n  \"Version\": \"6.0\",\n  \"Accept\": \"application/json\",\n  \"Content-Type\": \"application/json\"\n}",
+                  "endpoint": "/siem/offenses/13",
+                  "request_parameters": "{}"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "invoke_api",
+                "operationTitle": "Invoke QRadar API",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "128",
+              "left": "218",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "109c88dd-21f2-4c15-81ee-4ac91e113053"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "d77bf7fa-fe90-430d-b792-b9ab3af240bb",
+                "title": "IBM QRadar: Invoke QRadar REST API",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "40",
+              "left": "71",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "76fa16a1-bc32-48ac-a7af-6f9e7387d988"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Invoke QRadar API",
+              "targetStep": "/api/3/workflow_steps/109c88dd-21f2-4c15-81ee-4ac91e113053",
+              "sourceStep": "/api/3/workflow_steps/76fa16a1-bc32-48ac-a7af-6f9e7387d988",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "b8a32dcc-c2a6-412e-8543-810e4b9bc385"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "43db184d-cae3-4187-8ee7-ba0da320f0d8",
+          "id": 2336,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
         {
           "@type": "Workflow",
           "triggerLimit": null,
@@ -30,92 +1329,11 @@
           "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": 1657284948,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
           "versions": [],
-          "triggerStep": "/api/3/workflow_steps/f63d8750-ff67-427f-bf84-874f5cf55c9e",
+          "triggerStep": "/api/3/workflow_steps/283fb54c-26cb-495b-9914-083ba46fcab2",
           "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Create Alert",
-              "description": null,
-              "arguments": {
-                "when": "{{( vars.steps.Fetch_Offenses.data!= None) and ( vars.steps.Fetch_Offenses.data| length > 0)}}",
-                "for_each": {
-                  "item": "{{ vars.steps.Fetch_Offenses.data}}",
-                  "parallel": false,
-                  "condition": ""
-                },
-                "arguments": {
-                  "sourcedata": "{{vars.item}}",
-                  "qradar_pull_time": "{{vars.qradar_pull_time}}"
-                },
-                "apply_async": false,
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/0abc2445-cf11-45fc-863c-c7dae89b43d2"
-              },
-              "status": null,
-              "top": "360",
-              "left": "700",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "uuid": "2774d9b5-0328-4899-ad00-987b64f44fd0"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Configuration",
-              "description": null,
-              "arguments": {
-                "qradar_timezone": "{{vars.steps.Fetch_Offenses.QRadarTimeZoneMacro}}",
-                "qradar_pull_time": "{{vars.steps.Fetch_Offenses.QRadarPullTimeMacro}}",
-                "qradar_event_limit": "{{vars.steps.Fetch_Offenses.QRadarLimitMacro}}"
-              },
-              "status": null,
-              "top": "260",
-              "left": "400",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "44b202e1-a4c5-4698-ae55-f88e9e2cf759"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Fetch Related Events of Offense",
-              "description": null,
-              "arguments": {
-                "when": "{{vars.steps.Create_Alert}}",
-                "for_each": {
-                  "item": "{{vars.steps.Create_Alert}}",
-                  "parallel": false,
-                  "condition": ""
-                },
-                "arguments": {
-                  "alertRecord": "{{vars.item}}",
-                  "qradar_timezone": "{{vars.qradar_timezone}}",
-                  "qradar_event_limit": "{{vars.qradar_event_limit}}"
-                },
-                "apply_async": true,
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/a0f9a5b4-c8d9-418c-a703-4acb02066346"
-              },
-              "status": null,
-              "top": "520",
-              "left": "1340",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "uuid": "81a6700d-f7b8-4d4f-be42-fe1d41c2ab72"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Fetch Offenses",
-              "description": null,
-              "arguments": {
-                "arguments": [],
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/125d079a-13f1-44fa-a75f-4294aafc643b"
-              },
-              "status": null,
-              "top": "140",
-              "left": "240",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "uuid": "a1d384da-5cdb-474b-bbea-988cd481632d"
-            },
             {
               "@type": "WorkflowStep",
               "name": "Update Last Offense Pull Time",
@@ -136,14 +1354,15 @@
               "top": "440",
               "left": "1020",
               "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "cc5c10e1-d0ad-4892-a2e7-6bc2e5e29923"
+              "group": null,
+              "uuid": "14c9264f-1c06-4c1f-99ac-b35c8ea98884"
             },
             {
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "arguments": {
-                "route": "3095f149-1c11-4259-98da-091cbb6db79b",
+                "route": "dbd52964-3a44-49cb-ae8b-f678a24879e2",
                 "title": "QRadar > Fetch Offenses Now",
                 "resources": [
                   "alerts"
@@ -176,63 +1395,146 @@
               "top": "20",
               "left": "40",
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "f63d8750-ff67-427f-bf84-874f5cf55c9e"
+              "group": null,
+              "uuid": "283fb54c-26cb-495b-9914-083ba46fcab2"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Configuration",
+              "description": null,
+              "arguments": {
+                "qradar_timezone": "{{vars.steps.Fetch_Offenses.QRadarTimeZoneMacro}}",
+                "qradar_pull_time": "{{vars.steps.Fetch_Offenses.QRadarPullTimeMacro}}",
+                "qradar_event_limit": "{{vars.steps.Fetch_Offenses.QRadarLimitMacro}}"
+              },
+              "status": null,
+              "top": "260",
+              "left": "400",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "2bf62ac7-c19c-401f-8423-d61a296f5890"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Fetch Related Events of Offense",
+              "description": null,
+              "arguments": {
+                "when": "{{vars.steps.Create_Alert}}",
+                "for_each": {
+                  "item": "{{vars.steps.Create_Alert}}",
+                  "parallel": false,
+                  "condition": ""
+                },
+                "arguments": {
+                  "alertRecord": "{{vars.item}}",
+                  "qradar_timezone": "{{vars.qradar_timezone}}",
+                  "qradar_event_limit": "{{vars.qradar_event_limit}}"
+                },
+                "apply_async": true,
+                "step_variables": [],
+                "workflowReference": "/api/3/workflows/121ddc91-e89f-47ca-acdd-f1adad50ef31"
+              },
+              "status": null,
+              "top": "520",
+              "left": "1340",
+              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+              "group": null,
+              "uuid": "abc0d3dc-5617-45e7-847d-0899c737a09d"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Create Alert",
+              "description": null,
+              "arguments": {
+                "when": "{{( vars.steps.Fetch_Offenses.data!= None) and ( vars.steps.Fetch_Offenses.data| length > 0)}}",
+                "for_each": {
+                  "item": "{{ vars.steps.Fetch_Offenses.data}}",
+                  "parallel": false,
+                  "condition": ""
+                },
+                "arguments": {
+                  "sourcedata": "{{vars.item}}",
+                  "qradar_pull_time": "{{vars.qradar_pull_time}}"
+                },
+                "apply_async": false,
+                "step_variables": [],
+                "workflowReference": "/api/3/workflows/e02a2669-6396-46ad-bb07-b27a5f5004e7"
+              },
+              "status": null,
+              "top": "360",
+              "left": "700",
+              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+              "group": null,
+              "uuid": "bbd51da9-9f3d-4db9-9354-1769d0da62b8"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Fetch Offenses",
+              "description": null,
+              "arguments": {
+                "arguments": [],
+                "step_variables": [],
+                "workflowReference": "/api/3/workflows/8dd94c81-fc84-4675-b7b2-28a8fd020ea2"
+              },
+              "status": null,
+              "top": "140",
+              "left": "240",
+              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+              "group": null,
+              "uuid": "f927e5f9-6943-41d1-a7ef-569b29a6d35e"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
               "name": "Start -> Fetch Offenses",
-              "targetStep": "/api/3/workflow_steps/a1d384da-5cdb-474b-bbea-988cd481632d",
-              "sourceStep": "/api/3/workflow_steps/f63d8750-ff67-427f-bf84-874f5cf55c9e",
+              "targetStep": "/api/3/workflow_steps/f927e5f9-6943-41d1-a7ef-569b29a6d35e",
+              "sourceStep": "/api/3/workflow_steps/283fb54c-26cb-495b-9914-083ba46fcab2",
               "label": null,
               "isExecuted": false,
-              "uuid": "7e50d117-57a0-4279-884d-9deaba13eb4e"
+              "uuid": "a128dccb-8a71-43ec-a234-d936808bf71a"
             },
             {
               "@type": "WorkflowRoute",
               "name": "Create Alert -> Update Last Offense Pull Time",
-              "targetStep": "/api/3/workflow_steps/cc5c10e1-d0ad-4892-a2e7-6bc2e5e29923",
-              "sourceStep": "/api/3/workflow_steps/2774d9b5-0328-4899-ad00-987b64f44fd0",
+              "targetStep": "/api/3/workflow_steps/14c9264f-1c06-4c1f-99ac-b35c8ea98884",
+              "sourceStep": "/api/3/workflow_steps/bbd51da9-9f3d-4db9-9354-1769d0da62b8",
               "label": null,
               "isExecuted": false,
-              "uuid": "99bb5b2d-e822-4a7a-a5e1-a9c43770f6a5"
+              "uuid": "b9a939f1-d2f9-4b02-b2d8-7a8ad9336a64"
             },
             {
               "@type": "WorkflowRoute",
               "name": "Update Last Offense Pull Time -> Fetch Related Events of Offense",
-              "targetStep": "/api/3/workflow_steps/81a6700d-f7b8-4d4f-be42-fe1d41c2ab72",
-              "sourceStep": "/api/3/workflow_steps/cc5c10e1-d0ad-4892-a2e7-6bc2e5e29923",
+              "targetStep": "/api/3/workflow_steps/abc0d3dc-5617-45e7-847d-0899c737a09d",
+              "sourceStep": "/api/3/workflow_steps/14c9264f-1c06-4c1f-99ac-b35c8ea98884",
               "label": null,
               "isExecuted": false,
-              "uuid": "0e571726-027b-4b4a-a415-94fe679a2e87"
+              "uuid": "5cb32040-1b51-4ea9-a5d8-839ad7f72edf"
             },
             {
               "@type": "WorkflowRoute",
               "name": "Fetch Offenses -> Configuration",
-              "targetStep": "/api/3/workflow_steps/44b202e1-a4c5-4698-ae55-f88e9e2cf759",
-              "sourceStep": "/api/3/workflow_steps/a1d384da-5cdb-474b-bbea-988cd481632d",
+              "targetStep": "/api/3/workflow_steps/2bf62ac7-c19c-401f-8423-d61a296f5890",
+              "sourceStep": "/api/3/workflow_steps/f927e5f9-6943-41d1-a7ef-569b29a6d35e",
               "label": null,
               "isExecuted": false,
-              "uuid": "66c5fe20-ec03-4bcc-aaf2-ebb98c60d733"
+              "uuid": "288d22d1-dd7b-42e1-8014-6b70a38040c3"
             },
             {
               "@type": "WorkflowRoute",
               "name": "Configuration -> Create Alert",
-              "targetStep": "/api/3/workflow_steps/2774d9b5-0328-4899-ad00-987b64f44fd0",
-              "sourceStep": "/api/3/workflow_steps/44b202e1-a4c5-4698-ae55-f88e9e2cf759",
+              "targetStep": "/api/3/workflow_steps/bbd51da9-9f3d-4db9-9354-1769d0da62b8",
+              "sourceStep": "/api/3/workflow_steps/2bf62ac7-c19c-401f-8423-d61a296f5890",
               "label": null,
               "isExecuted": false,
-              "uuid": "4d44a5ca-b549-48a8-a0cc-0a727908ece7"
+              "uuid": "e3e005c1-c583-48e1-9ee1-ebefef67aaf6"
             }
           ],
+          "groups": [],
           "priority": null,
-          "uuid": "036abd4c-66c3-477e-8cec-1934ea66cd3f",
-          "id": 4584,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.809898,
-          "modifyUser": "/api/3/people/3451141c-bac6-467c-8d72-85e0fab569ce",
-          "modifyDate": 1657284946.561792,
+          "uuid": "45cc0a77-f7b7-473d-8479-c6889346fcff",
+          "id": 2326,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -240,6 +1542,1689 @@
           "recordTags": [
             "dataingestion",
             "ingest",
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Add Table Element",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Add or update an element in a reference table",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672638705,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/ea8ef95b-b363-455a-947e-9d0baec1bc86",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Add Table Element",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "e524c682-01c1-416b-94bb-40aa2f2e6f55",
+                "params": {
+                  "path.name": "ip_whitelist",
+                  "query.value": "331",
+                  "query.source": "FortiSOAR",
+                  "query.domain_id": "",
+                  "query.inner_key": "port",
+                  "query.outer_key": "10.21.3.2"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "add_table_element",
+                "operationTitle": "Add/Update Table Element",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "9825ea2c-a51f-414f-a759-9fd76bbc8aae"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "a9442cd8-0cb5-44d8-a2a2-885170d21eb1",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "ea8ef95b-b363-455a-947e-9d0baec1bc86"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Destination IP Addresses",
+              "targetStep": "/api/3/workflow_steps/9825ea2c-a51f-414f-a759-9fd76bbc8aae",
+              "sourceStep": "/api/3/workflow_steps/ea8ef95b-b363-455a-947e-9d0baec1bc86",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "2203fde8-f483-42bc-b448-c04e22bcb1e3"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "46bdf5aa-d0a8-4d1c-86ae-00f56436b2db",
+          "id": 2351,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Destination IP Addresses",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Get Details for the given destination IP Address Ids",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/60a06e05-8635-4094-b471-752bc88469db",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Destination IP Addresses",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "destination_address_ids": "[10]"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_destination_ip",
+                "operationTitle": "Get Destination IP Addresses",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "121",
+              "left": "163",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "01343e51-8a24-4939-8fc3-e4c00b8bcd7c"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "b26f4b29-9fb2-486e-a94e-517d7dde612d",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "60a06e05-8635-4094-b471-752bc88469db"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Destination IP Addresses",
+              "targetStep": "/api/3/workflow_steps/01343e51-8a24-4939-8fc3-e4c00b8bcd7c",
+              "sourceStep": "/api/3/workflow_steps/60a06e05-8635-4094-b471-752bc88469db",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "fb842ac2-c82f-495a-bd79-4c460bbda99a"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "561fe37c-e6ea-4b98-8661-05675ae13d52",
+          "id": 2343,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Cases",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Get a list of Qradar cases",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672638217,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/6ff709e9-8298-4a52-93f4-56924bc299e6",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Cases",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "e524c682-01c1-416b-94bb-40aa2f2e6f55",
+                "params": {
+                  "max_results": 100,
+                  "filter_string": ""
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_cases",
+                "operationTitle": "Get Cases",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "1f102639-ed9c-4424-ac65-24abea561ffa"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "ebac2c01-feb9-4218-b6f3-50e291394f32",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "6ff709e9-8298-4a52-93f4-56924bc299e6"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Destination IP Addresses",
+              "targetStep": "/api/3/workflow_steps/1f102639-ed9c-4424-ac65-24abea561ffa",
+              "sourceStep": "/api/3/workflow_steps/6ff709e9-8298-4a52-93f4-56924bc299e6",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "cb7807b6-0fad-4c03-b4a1-5d4f4db0876b"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "5fdbbd0f-5ce8-4627-aad0-9e5d22384e6b",
+          "id": 2347,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": ">> IBM QRadar > Init Macros",
+          "aliasName": null,
+          "tag": "#qradar #dataingestion",
+          "description": "This playbook creates IBM QRadar macros if not exist.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [
+            "QRadarMacroName",
+            "QRadarMacroValue",
+            "overrideIfNoMatch"
+          ],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/f4287255-5efb-4c2d-bbb9-2e869e46eee4",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Create IBM QRadar Macro",
+              "description": null,
+              "arguments": {
+                "params": {
+                  "iri": "/api/wf/api/dynamic-variable/?format=json",
+                  "body": "{ 'name': '{{vars.QRadarMacroName}}'   , 'value': '{{vars.QRadarMacroValue}}' }",
+                  "method": "POST"
+                },
+                "version": "2.5.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "CyOPs: Make CyOPs API Call",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "306",
+              "left": "651",
+              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+              "group": null,
+              "uuid": "08edecca-3ccf-478d-b0d0-9e3f5b640a9f"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Get QRadar Macros",
+              "description": null,
+              "arguments": {
+                "name": "Utilities",
+                "params": {
+                  "iri": "/api/wf/api/dynamic-variable/?format=json&name={{vars.QRadarMacroName}}",
+                  "body": "",
+                  "method": "GET"
+                },
+                "version": "2.5.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "CyOPs: Make CyOPs API Call",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "120",
+              "left": "171",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "0a3c8807-4c31-4e5f-bf0b-8ff8e14e57d7"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "QRadar Macro Exists",
+              "description": null,
+              "arguments": {
+                "conditions": [
+                  {
+                    "option": "Not Exist",
+                    "step_iri": "/api/3/workflow_steps/08edecca-3ccf-478d-b0d0-9e3f5b640a9f",
+                    "condition": "{{ vars.steps.Get_QRadar_Macros.data['hydra:totalItems'] == 0 }}"
+                  },
+                  {
+                    "option": "Exist",
+                    "default": true,
+                    "step_iri": "/api/3/workflow_steps/a45e94c4-ed54-4195-8c79-6397b5a9f6d9"
+                  }
+                ]
+              },
+              "status": null,
+              "top": "228",
+              "left": "320",
+              "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+              "group": null,
+              "uuid": "7118c6b9-a139-4322-93e4-aab16845e927"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Update Macro If Required",
+              "description": null,
+              "arguments": {
+                "when": "{{(vars.input.params.overrideIfNoMatch  == true) and (vars.macroExistingRecord.value != vars.QRadarMacroValue)}}",
+                "params": {
+                  "iri": "/api/wf/api/dynamic-variable/{{ vars.macroExistingRecord.id }}/",
+                  "body": "{ 'name': '{{vars.QRadarMacroName}}'   , 'value': '{{vars.QRadarMacroValue}}' }",
+                  "method": "PUT"
+                },
+                "version": "2.7.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "CyOPs: Make CyOPs API Call",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "147",
+              "left": "952",
+              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+              "group": null,
+              "uuid": "9d0fe7ad-f177-47b0-abef-84cb6110734b"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Fetch Macro Current Value",
+              "description": null,
+              "arguments": {
+                "macroExistingRecord": "{{vars.steps.Get_QRadar_Macros.data['hydra:member'][0]}}"
+              },
+              "status": null,
+              "top": "147",
+              "left": "651",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "a45e94c4-ed54-4195-8c79-6397b5a9f6d9"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "step_variables": {
+                  "input": {
+                    "params": {
+                      "QRadarMacroName": "{{ vars.QRadarMacroName }}",
+                      "QRadarMacroValue": "{{ vars.QRadarMacroValue }}",
+                      "overrideIfNoMatch": "{{ vars.overrideIfNoMatch }}"
+                    }
+                  }
+                }
+              },
+              "status": null,
+              "top": "20",
+              "left": "20",
+              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+              "group": null,
+              "uuid": "f4287255-5efb-4c2d-bbb9-2e869e46eee4"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Check IBM QRadar Macro -> Create IBM QRadar Macro",
+              "targetStep": "/api/3/workflow_steps/08edecca-3ccf-478d-b0d0-9e3f5b640a9f",
+              "sourceStep": "/api/3/workflow_steps/7118c6b9-a139-4322-93e4-aab16845e927",
+              "label": "Not Exist",
+              "isExecuted": false,
+              "uuid": "136ad3aa-a7f7-42e1-8bc0-bf4eb3885cf5"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Fetch Macro Current Value -> Update Macro If Required",
+              "targetStep": "/api/3/workflow_steps/9d0fe7ad-f177-47b0-abef-84cb6110734b",
+              "sourceStep": "/api/3/workflow_steps/a45e94c4-ed54-4195-8c79-6397b5a9f6d9",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "27c8eeaf-afba-4b0d-9567-512806b3fda6"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Get All Macros -> Check IBM QRadar Macro",
+              "targetStep": "/api/3/workflow_steps/7118c6b9-a139-4322-93e4-aab16845e927",
+              "sourceStep": "/api/3/workflow_steps/0a3c8807-4c31-4e5f-bf0b-8ff8e14e57d7",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "7f86ffce-e937-4982-af95-68f6049a6f76"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Get All Macros",
+              "targetStep": "/api/3/workflow_steps/0a3c8807-4c31-4e5f-bf0b-8ff8e14e57d7",
+              "sourceStep": "/api/3/workflow_steps/f4287255-5efb-4c2d-bbb9-2e869e46eee4",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "06c27583-dd3e-4a9b-b58a-8863f8bf3704"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "QRadar Macro Exists -> Fetch Macro Current Value",
+              "targetStep": "/api/3/workflow_steps/a45e94c4-ed54-4195-8c79-6397b5a9f6d9",
+              "sourceStep": "/api/3/workflow_steps/7118c6b9-a139-4322-93e4-aab16845e927",
+              "label": "Exist",
+              "isExecuted": false,
+              "uuid": "93c8062e-e99c-405e-80c4-e01090f67a06"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "7275fa64-bf3b-48a6-bbe0-5afc47a5c9fe",
+          "id": 2330,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "dataingestion",
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Delete Table Element",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Delete element from a reference table",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672638677,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/8ccf441c-745d-4964-bd2c-d92603fe1543",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "5b61e4cb-f17d-4a71-b506-7de15fc41194",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "8ccf441c-745d-4964-bd2c-d92603fe1543"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Delete Table Element",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "e524c682-01c1-416b-94bb-40aa2f2e6f55",
+                "params": {
+                  "path.name": "ip_whitelist",
+                  "query.value": "331",
+                  "query.source": "FortiSOAR",
+                  "path.inner_key": "port",
+                  "path.outer_key": "10.21.3.2",
+                  "query.domain_id": ""
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "delete_table_element",
+                "operationTitle": "Delete Table Element",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "ce1c6528-6753-4c92-84c7-5f188f9e00c2"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Destination IP Addresses",
+              "targetStep": "/api/3/workflow_steps/ce1c6528-6753-4c92-84c7-5f188f9e00c2",
+              "sourceStep": "/api/3/workflow_steps/8ccf441c-745d-4964-bd2c-d92603fe1543",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "87b05888-3aac-4501-96ea-2ca2249893b1"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "7c455389-2777-472b-8857-a246c87ca909",
+          "id": 2352,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "> IBM QRadar > Fetch",
+          "aliasName": null,
+          "tag": "#qradar #fetch #dataingestion",
+          "description": "This playbook fetches the Offenses.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/657d2dda-e4c1-46eb-b5fa-3b0b1f52cff0",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Offenses",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "filter_string": "{{vars.filter_string}} and (start_time > '{{vars.qradar_epoch}}' or last_updated_time > '{{vars.qradar_epoch}}' )"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_offenses",
+                "operationTitle": "Get Offenses from QRadar",
+                "step_variables": {
+                  "all_offenses": "{{ vars.result.data }}"
+                }
+              },
+              "status": null,
+              "top": "860",
+              "left": "840",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "131fade4-8fda-48be-abc5-fdcc3c2749ec"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Configuration",
+              "description": null,
+              "arguments": {
+                "macro_name": "{{vars['audit_info']['cyops_playbook_iri'].split('/')[-1].replace('-','_')}}",
+                "filter_string": "status=\"OPEN\"",
+                "qradar_timezone": "UTC",
+                "event_record_limit": "50",
+                "Pull_Sample_Offense_in_Past_X_Minutes": "10"
+              },
+              "status": null,
+              "top": "180",
+              "left": "80",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "1cc9b5a1-2aa3-46cd-9fd4-227c46dde612"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Update Offenses With IP Details",
+              "description": null,
+              "arguments": {
+                "_dummy_for_src_addrs": "{% for each_offense in vars.all_offenses %}\n {% set offense_src_ips = [] %}\n {% for each_ip in vars.steps.Get_Source_Address_Details.data %}\n {% if each_ip.id in each_offense.source_address_ids %}\n {% set _temp =  offense_src_ips.append(each_ip) %}\n {% endif %}\n{% endfor %}\n{% set _temp2 = each_offense.update({\"source_address_details\": offense_src_ips}) %}\n {% endfor %}",
+                "_dummy_for_dest_addrs": "{% for each_offense in vars.all_offenses %}\n {% set offense_dest_ips = [] %}\n {% for each_ip in vars.steps.Get_Destination_Address_Details.data %}\n {% if each_ip.id in each_offense.local_destination_address_ids %}\n {% set _temp =  offense_dest_ips.append(each_ip) %}\n{% endif %}\n{% endfor %}\n{% set _temp2 = each_offense.update({\"destination_address_details\": offense_dest_ips}) %}\n {% endfor %}"
+              },
+              "status": null,
+              "top": "1320",
+              "left": "1040",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "2885f619-70be-47f0-885a-68ed9d5c5553"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Destination Address Details",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "when": "{{(vars.all_offenses | length > 0) and (vars.destinations_ips | length > 0)}}",
+                "config": "",
+                "params": {
+                  "destination_address_ids": "{{vars.destinations_ips}}"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_destination_ip",
+                "operationTitle": "Get Destination IP Addresses",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "1200",
+              "left": "1040",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "3eb65aa1-cbff-4b17-a840-ede2a0211025"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "step_variables": {
+                  "input": {
+                    "params": []
+                  },
+                  "_configuration_schema": "[{\n\t\t\"title\": \"Search Query\",\n\t\t\"tooltip\": \"The Query to be run on QRadar to fetch offenses\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"text\",\n\t\t\"name\": \"filter_string\",\n\t\t\"value\": \"status=\\\"OPEN\\\"\"\n\t}, {\n\t\t\"title\": \"Pull Offenses in the last X minutes\",\n\t\t\"tooltip\": \"Limit the search query specified above to filter the offenses created or modified in the last X minutes\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"text\",\n\t\t\"name\": \"Pull_Sample_Offense_in_Past_X_Minutes\",\n\t\t\"value\": 10\n\n\t},\n\t{\n\t\t\"title\": \"Timezone of the QRadar server\",\n\t\t\"tooltip\": \"Required for the time conversion to pull events since the last X minutes for an offense\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"text\",\n\t\t\"name\": \"qradar_timezone\",\n\t\t\"value\": \"UTC\"\n\n\t},\n\t{\n\t\t\"title\": \"Event Record Limit\",\n\t\t\"tooltip\": \"Pull number of events for an offense\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"integer\",\n\t\t\"name\": \"event_record_limit\",\n\t\t\"value\": 50\n\t}\n]"
+                }
+              },
+              "status": null,
+              "top": "60",
+              "left": "80",
+              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+              "group": null,
+              "uuid": "657d2dda-e4c1-46eb-b5fa-3b0b1f52cff0"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Create Macro List",
+              "description": null,
+              "arguments": {
+                "macro_list": "[{\"macro_name\": \"QRadarLastOffensePullTime_{{vars.macro_name}}\" , \"macro_value\": 0, \"override\": false},{\"macro_name\": \"QRadarTimeZone_{{vars.macro_name}}\" , \"macro_value\": \"{{vars.qradar_timezone}}\", \"override\": true},{\"macro_name\": \"QRadarEventLimit_{{vars.macro_name}}\" , \"macro_value\": \"{{vars.event_record_limit}}\", \"override\": true}]"
+              },
+              "status": null,
+              "top": "280",
+              "left": "80",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "668f5074-fee0-4b2e-81b0-277b621fc7e4"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Calculate QRadar Epoch Time",
+              "description": null,
+              "arguments": {
+                "qradar_epoch": "{{ ( arrow.get(vars.curr_timestamp).shift(minutes=-vars.time_diff_min).int_timestamp) * 1000}}"
+              },
+              "status": null,
+              "top": "760",
+              "left": "680",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "7f2546ca-2387-4afa-8c45-a6d6a91180f9"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Set Time Configuration",
+              "description": null,
+              "arguments": {
+                "curr_timestamp": "{{arrow.utcnow().int_timestamp}}",
+                "last_pull_time": "{% if (vars.steps.Get_Macro_Value.data[\"hydra:member\"] | length) > 0 and vars.steps.Get_Macro_Value.data[\"hydra:member\"][0].value | int  > 0 %}{{vars.steps.Get_Macro_Value.data[\"hydra:member\"][0].value}}{% else %}{{ (arrow.utcnow().int_timestamp) - (vars.Pull_Sample_Offense_in_Past_X_Minutes| int)  *60 }}{% endif %}"
+              },
+              "status": null,
+              "top": "520",
+              "left": "480",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "a1e6bf71-a6f8-42ce-8645-305c8696fcd1"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Environment Setup",
+              "description": null,
+              "arguments": {
+                "when": "{{vars.request.env_setup}}",
+                "for_each": {
+                  "item": "{{vars.macro_list}}",
+                  "__bulk": false,
+                  "parallel": true,
+                  "condition": ""
+                },
+                "arguments": {
+                  "QRadarMacroName": "{{vars.item.macro_name}}",
+                  "QRadarMacroValue": "{{vars.item.macro_value}}",
+                  "overrideIfNoMatch": "{{vars.item.override}}"
+                },
+                "apply_async": false,
+                "step_variables": [],
+                "workflowReference": "/api/3/workflows/7275fa64-bf3b-48a6-bbe0-5afc47a5c9fe"
+              },
+              "status": null,
+              "top": "280",
+              "left": "480",
+              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+              "group": null,
+              "uuid": "a3f84a6b-350a-434e-bc66-f67b854cf776"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Set Result",
+              "description": null,
+              "arguments": {
+                "data": "{{vars.all_offenses}}",
+                "curr_timestamp": "{{vars.curr_timestamp}}",
+                "QRadarLimitMacro": "{{vars.macro_list[2].get(\"macro_value\")}}",
+                "QRadarPullTimeMacro": "{{vars.macro_list[0].get(\"macro_name\")}}",
+                "QRadarTimeZoneMacro": "{{vars.macro_list[1].get(\"macro_value\")}}"
+              },
+              "status": null,
+              "top": "1460",
+              "left": "1040",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "b3c0b461-0732-42a6-992e-26aa9ef12fc3"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Collect IP ids",
+              "description": null,
+              "arguments": {
+                "src_ips": "{{ vars.steps.Get_Offenses.data | json_query('[*].source_address_ids[]') }}",
+                "destinations_ips": "{{ vars.steps.Get_Offenses.data | json_query('[*].local_destination_address_ids[]') }}"
+              },
+              "status": null,
+              "top": "980",
+              "left": "840",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "b42e44c5-6d06-4417-8d55-7d75f5798398"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Calculate Diff in min",
+              "description": null,
+              "arguments": {
+                "time_diff_min": "{{ (vars.curr_timestamp - vars.last_pull_time) / 60 | round }}"
+              },
+              "status": null,
+              "top": "620",
+              "left": "680",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "b7e2d7b1-5422-4f03-9244-48fb751805c3"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Macro Value",
+              "description": null,
+              "arguments": {
+                "params": {
+                  "iri": "/api/wf/api/dynamic-variable/?name={{vars.macro_list[0].get(\"macro_name\")}}",
+                  "body": "",
+                  "method": "GET"
+                },
+                "version": "3.2.1",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "400",
+              "left": "480",
+              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+              "group": null,
+              "uuid": "c5dc2c99-c7f5-468b-8016-6f0562f7c33f"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Source Address Details",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "when": "{{(vars.all_offenses | length > 0) and (vars.src_ips | length > 0)}}",
+                "config": "",
+                "params": {
+                  "source_address_ids": "{{vars.src_ips}}"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_source_ip",
+                "operationTitle": "Get Source IP Addresses",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "1080",
+              "left": "1040",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "d3100967-089d-4795-a083-0742e14ba127"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Collect IP ids -> Get Source IP Details",
+              "targetStep": "/api/3/workflow_steps/d3100967-089d-4795-a083-0742e14ba127",
+              "sourceStep": "/api/3/workflow_steps/b42e44c5-6d06-4417-8d55-7d75f5798398",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "51cc744d-08d1-4aee-9734-5aaf853cde03"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Set Time Configuration -> Calculate Diff in min",
+              "targetStep": "/api/3/workflow_steps/b7e2d7b1-5422-4f03-9244-48fb751805c3",
+              "sourceStep": "/api/3/workflow_steps/a1e6bf71-a6f8-42ce-8645-305c8696fcd1",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "7faf7b13-c78d-41f4-a498-b695f28f7c98"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Create QRadar Last Offense Pull Time Macro -> Get Macro Value",
+              "targetStep": "/api/3/workflow_steps/c5dc2c99-c7f5-468b-8016-6f0562f7c33f",
+              "sourceStep": "/api/3/workflow_steps/a3f84a6b-350a-434e-bc66-f67b854cf776",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "9e969142-7da9-4564-b965-a3fb653b2d2d"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Configuration -> Copy of Configuration",
+              "targetStep": "/api/3/workflow_steps/668f5074-fee0-4b2e-81b0-277b621fc7e4",
+              "sourceStep": "/api/3/workflow_steps/1cc9b5a1-2aa3-46cd-9fd4-227c46dde612",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "6fc7986e-8aba-4506-8f5e-914f4d047b6e"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Calculate QRadar Epoch Time -> Get Offenses",
+              "targetStep": "/api/3/workflow_steps/131fade4-8fda-48be-abc5-fdcc3c2749ec",
+              "sourceStep": "/api/3/workflow_steps/7f2546ca-2387-4afa-8c45-a6d6a91180f9",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "11424229-3b93-40d9-998f-8e1cb4f2179f"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Create Macro List -> Create QRadar Last Offense Pull Time Macro",
+              "targetStep": "/api/3/workflow_steps/a3f84a6b-350a-434e-bc66-f67b854cf776",
+              "sourceStep": "/api/3/workflow_steps/668f5074-fee0-4b2e-81b0-277b621fc7e4",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "5e89ba2c-e607-4c40-9e88-7c2373946b5a"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Calculate Diff in min -> Calculate QRadar Epoch Time",
+              "targetStep": "/api/3/workflow_steps/7f2546ca-2387-4afa-8c45-a6d6a91180f9",
+              "sourceStep": "/api/3/workflow_steps/b7e2d7b1-5422-4f03-9244-48fb751805c3",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "02144a78-a392-4873-b03b-17d35e35f40f"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Update Offenses With IP Details -> Set Result",
+              "targetStep": "/api/3/workflow_steps/b3c0b461-0732-42a6-992e-26aa9ef12fc3",
+              "sourceStep": "/api/3/workflow_steps/2885f619-70be-47f0-885a-68ed9d5c5553",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "a035880c-350e-4b19-a902-c501f65ea963"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Get Offenses -> Collect IP ids",
+              "targetStep": "/api/3/workflow_steps/b42e44c5-6d06-4417-8d55-7d75f5798398",
+              "sourceStep": "/api/3/workflow_steps/131fade4-8fda-48be-abc5-fdcc3c2749ec",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "fe97389d-e7d9-4c0d-838e-63d21010fdd7"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Configuration",
+              "targetStep": "/api/3/workflow_steps/1cc9b5a1-2aa3-46cd-9fd4-227c46dde612",
+              "sourceStep": "/api/3/workflow_steps/657d2dda-e4c1-46eb-b5fa-3b0b1f52cff0",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "d50583ee-5e48-4a16-9a4c-d5f57ddbe15d"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Get Macro Value -> Set Time Configuration",
+              "targetStep": "/api/3/workflow_steps/a1e6bf71-a6f8-42ce-8645-305c8696fcd1",
+              "sourceStep": "/api/3/workflow_steps/c5dc2c99-c7f5-468b-8016-6f0562f7c33f",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "ca71a84d-cbd0-4a76-a118-6c4bddace753"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Get Destination Address Details -> Update Offenses With IP Details",
+              "targetStep": "/api/3/workflow_steps/2885f619-70be-47f0-885a-68ed9d5c5553",
+              "sourceStep": "/api/3/workflow_steps/3eb65aa1-cbff-4b17-a840-ede2a0211025",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "e2080169-56c7-4e91-ae56-4eefa971d7ab"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Get Source IP Details -> Get Destination Address Details",
+              "targetStep": "/api/3/workflow_steps/3eb65aa1-cbff-4b17-a840-ede2a0211025",
+              "sourceStep": "/api/3/workflow_steps/d3100967-089d-4795-a083-0742e14ba127",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "50690fec-3bee-465a-a26a-eba71049ff75"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "8dd94c81-fc84-4675-b7b2-28a8fd020ea2",
+          "id": 2328,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "dataingestion",
+            "fetch",
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Create Cases",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Create a new case on Qradar",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672638319,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/33b7724b-3168-4003-8af3-63cddc3d9820",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "c5febc8e-5486-4a84-84cf-a8c88f76600b",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "33b7724b-3168-4003-8af3-63cddc3d9820"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Create Cases",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "e524c682-01c1-416b-94bb-40aa2f2e6f55",
+                "params": {
+                  "body.case": "{\r\n    \"assigned_to\": [\r\n        \"admin\"\r\n    ],\r\n    \"name\": \"case19\"\r\n}"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "create_case",
+                "operationTitle": "Create Case",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "f94dec7c-e2e5-4450-9c53-ad8204bf7750"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Destination IP Addresses",
+              "targetStep": "/api/3/workflow_steps/f94dec7c-e2e5-4450-9c53-ad8204bf7750",
+              "sourceStep": "/api/3/workflow_steps/33b7724b-3168-4003-8af3-63cddc3d9820",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "2e0664d4-de9d-4230-b411-011ec28c194f"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "976a2218-75ec-465b-bc06-4b5db6715fdd",
+          "id": 2348,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "> Close Offense",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "This playbook is continuation of sample playbook for Operation- Get Offense Closing Reasons",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [
+            "offenseID",
+            "reasonID"
+          ],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/d03703fc-3e08-428e-9b44-477cff2fac0d",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Set Offense Id",
+              "description": null,
+              "arguments": {
+                "reason_id": "{{vars.reasonID}}",
+                "offense_id": "{{vars.offenseID.sourceId}}"
+              },
+              "status": null,
+              "top": "149",
+              "left": "240",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "9a325e12-d439-4ca3-a9ca-09c488a61e23"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Close Offense",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "offense_id": "{{ vars.offense_id }}",
+                  "closure_note": "",
+                  "offense_close_id": "{{ vars.reason_id }}"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "close_offense",
+                "operationTitle": "Close Offense",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "260",
+              "left": "240",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "bd0b17af-1f9b-4e2d-8c93-7e04e446445b"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "step_variables": {
+                  "input": {
+                    "params": {
+                      "reasonID": "{{ vars.reasonID }}",
+                      "offenseID": "{{ vars.offenseID }}"
+                    }
+                  }
+                }
+              },
+              "status": null,
+              "top": "40",
+              "left": "240",
+              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+              "group": null,
+              "uuid": "d03703fc-3e08-428e-9b44-477cff2fac0d"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Set Offense Id -> Close",
+              "targetStep": "/api/3/workflow_steps/bd0b17af-1f9b-4e2d-8c93-7e04e446445b",
+              "sourceStep": "/api/3/workflow_steps/9a325e12-d439-4ca3-a9ca-09c488a61e23",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "618c5fd6-934b-493c-93f2-fa8028717428"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Set Offense Id",
+              "targetStep": "/api/3/workflow_steps/9a325e12-d439-4ca3-a9ca-09c488a61e23",
+              "sourceStep": "/api/3/workflow_steps/d03703fc-3e08-428e-9b44-477cff2fac0d",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "eaa3075d-5625-49de-8759-a240120ece97"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "a24ecd78-2b91-4a05-88f0-657922cad26d",
+          "id": 2342,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Run Ariel Query",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "This playbook demonstrate Make an Ariel Query To QRadar Operation",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/0c512069-d46c-43c5-a122-28bdc5fe831a",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "37f855bc-1ffc-4da9-8484-1a17cf91e659",
+                "title": "IBM QRadar: Run Ariel Query",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "60",
+              "left": "86",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "0c512069-d46c-43c5-a122-28bdc5fe831a"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Search Result",
+              "description": null,
+              "arguments": {
+                "resultData": "{{vars.result}}"
+              },
+              "status": null,
+              "top": "271",
+              "left": "448",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "2ab4575b-c148-4c62-b558-b103908972a9"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Run Ariel Query",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "search_string": "show tables"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "query_qradar",
+                "operationTitle": "Make an Ariel Query to QRadar",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "147",
+              "left": "220",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "b96f2976-8240-409e-89af-016c1fe688e2"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Run Ariel Query -> SearchResult",
+              "targetStep": "/api/3/workflow_steps/2ab4575b-c148-4c62-b558-b103908972a9",
+              "sourceStep": "/api/3/workflow_steps/b96f2976-8240-409e-89af-016c1fe688e2",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "78831832-c367-4d31-9829-368f72c37507"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Run Ariel Query",
+              "targetStep": "/api/3/workflow_steps/b96f2976-8240-409e-89af-016c1fe688e2",
+              "sourceStep": "/api/3/workflow_steps/0c512069-d46c-43c5-a122-28bdc5fe831a",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "225aea99-95f5-4e54-a3d8-b6ff13190622"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "a4ef4200-a88c-4599-9050-ad29eb1eb0c6",
+          "id": 2329,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Offense Notes",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Retrieve a list of notes for an offense from QRadar.",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/bf9ebb1c-59b0-435c-9ce5-3b8e56e295f9",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Offense Notes",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": {
+                  "offense_id": "286"
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_notes",
+                "operationTitle": "Get Offense Notes",
+                "step_variables": {
+                  "output_data": "{{vars.result.data}}"
+                }
+              },
+              "status": null,
+              "top": "113",
+              "left": "200",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "b5ad6f29-bf00-4df7-a0d9-932e6867946d"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "3b3dc2e9-ea11-42e5-bf9a-9373fd43d668",
+                "title": "IBM QRadar: Get Offense Notes",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "20",
+              "left": "200",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "bf9ebb1c-59b0-435c-9ce5-3b8e56e295f9"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Get Reasons",
+              "targetStep": "/api/3/workflow_steps/b5ad6f29-bf00-4df7-a0d9-932e6867946d",
+              "sourceStep": "/api/3/workflow_steps/bf9ebb1c-59b0-435c-9ce5-3b8e56e295f9",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "b48130c1-d772-4dc2-951e-ec4951ca16a3"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "b2c101cf-e2f1-4d38-b547-4a4d95fdb2be",
+          "id": 2331,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Offense Type",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "This playbook demonstrate Get Offense Type. Offense Type can be used with Get Offense operation as a filter",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/2d5be1e3-d708-4069-ba3d-68576b3eed0b",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "4d1199fb-8f55-4637-aa22-bcb979a7a932",
+                "title": "IBM QRadar: Get Offense Type",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "108",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "2d5be1e3-d708-4069-ba3d-68576b3eed0b"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Offenses Type",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "",
+                "params": [],
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_offense_type",
+                "operationTitle": "Get Offense Types",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "135",
+              "left": "250",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "f6e6d7f0-fe0e-40bd-be62-46322718169c"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Get Offenses Type",
+              "targetStep": "/api/3/workflow_steps/f6e6d7f0-fe0e-40bd-be62-46322718169c",
+              "sourceStep": "/api/3/workflow_steps/2d5be1e3-d708-4069-ba3d-68576b3eed0b",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "ccc4cbc8-6939-4ce1-918f-48c01d8c512f"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "bdeed9d5-92c8-4bd3-a6ff-cd954efb12e1",
+          "id": 2335,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Assets",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Get a list of available assets",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672637213,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/f7913153-500f-45ec-a69f-454c330f733a",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Assets",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "e524c682-01c1-416b-94bb-40aa2f2e6f55",
+                "params": {
+                  "max_results": 100,
+                  "filter_string": ""
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_assets",
+                "operationTitle": "Get Assets",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "20b7216e-d295-4814-8981-5ebf79f99717"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "a2aaa527-898d-4fd8-82a6-c1fe55ba960c",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "f7913153-500f-45ec-a69f-454c330f733a"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Destination IP Addresses",
+              "targetStep": "/api/3/workflow_steps/20b7216e-d295-4814-8981-5ebf79f99717",
+              "sourceStep": "/api/3/workflow_steps/f7913153-500f-45ec-a69f-454c330f733a",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "c5d18310-7b0e-4021-a31e-cb0081740360"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "d71f0e35-3d5a-4935-8d2c-fe6d95115393",
+          "id": 2345,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
             "qradar"
           ]
         },
@@ -259,10 +3244,10 @@
             "qradar_pull_time"
           ],
           "synchronous": false,
-          "lastModifyDate": 1657284327,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
+          "lastModifyDate": 1672636518,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
           "versions": [],
-          "triggerStep": "/api/3/workflow_steps/ed236455-af84-4b80-98af-47592751294d",
+          "triggerStep": "/api/3/workflow_steps/621b3add-a965-405e-9d95-4c4ce6889861",
           "steps": [
             {
               "@type": "WorkflowStep",
@@ -277,7 +3262,8 @@
               "top": "100",
               "left": "220",
               "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "3d2e1316-8264-4c85-8935-2e76cb9a1c95"
+              "group": null,
+              "uuid": "2f9f6d0a-5458-4dc7-bb85-f05337d44a88"
             },
             {
               "@type": "WorkflowStep",
@@ -316,7 +3302,8 @@
               "top": "320",
               "left": "560",
               "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
-              "uuid": "bd67873d-2382-44b9-9791-0e6f4f05497e"
+              "group": null,
+              "uuid": "50ffc373-bb45-4126-9d6e-2a3b95fcaa57"
             },
             {
               "@type": "WorkflowStep",
@@ -336,7 +3323,8 @@
               "top": "20",
               "left": "20",
               "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "uuid": "ed236455-af84-4b80-98af-47592751294d"
+              "group": null,
+              "uuid": "621b3add-a965-405e-9d95-4c4ce6889861"
             },
             {
               "@type": "WorkflowStep",
@@ -365,45 +3353,43 @@
               "top": "200",
               "left": "380",
               "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
-              "uuid": "fcb9b6ef-76e1-422a-8018-e4c544c2068d"
+              "group": null,
+              "uuid": "6463119f-5b8d-4edb-bba4-a4c5d11d28f7"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
               "name": "Start -> Configuration",
-              "targetStep": "/api/3/workflow_steps/3d2e1316-8264-4c85-8935-2e76cb9a1c95",
-              "sourceStep": "/api/3/workflow_steps/ed236455-af84-4b80-98af-47592751294d",
+              "targetStep": "/api/3/workflow_steps/2f9f6d0a-5458-4dc7-bb85-f05337d44a88",
+              "sourceStep": "/api/3/workflow_steps/621b3add-a965-405e-9d95-4c4ce6889861",
               "label": null,
               "isExecuted": false,
-              "uuid": "f8effce8-693c-4a90-b28c-7921a7ece2e5"
+              "uuid": "fe56dd4d-30a0-4da2-b77c-7b94fb5f0ec8"
             },
             {
               "@type": "WorkflowRoute",
               "name": "Configuration -> Add a note of offense update",
-              "targetStep": "/api/3/workflow_steps/fcb9b6ef-76e1-422a-8018-e4c544c2068d",
-              "sourceStep": "/api/3/workflow_steps/3d2e1316-8264-4c85-8935-2e76cb9a1c95",
+              "targetStep": "/api/3/workflow_steps/6463119f-5b8d-4edb-bba4-a4c5d11d28f7",
+              "sourceStep": "/api/3/workflow_steps/2f9f6d0a-5458-4dc7-bb85-f05337d44a88",
               "label": null,
               "isExecuted": false,
-              "uuid": "5ec76e2c-c540-44f6-956a-b6b17d8946f8"
+              "uuid": "e76376a8-0b36-4765-a181-191df60b3483"
             },
             {
               "@type": "WorkflowRoute",
               "name": "Add a note of offense update -> Create Record",
-              "targetStep": "/api/3/workflow_steps/bd67873d-2382-44b9-9791-0e6f4f05497e",
-              "sourceStep": "/api/3/workflow_steps/fcb9b6ef-76e1-422a-8018-e4c544c2068d",
+              "targetStep": "/api/3/workflow_steps/50ffc373-bb45-4126-9d6e-2a3b95fcaa57",
+              "sourceStep": "/api/3/workflow_steps/6463119f-5b8d-4edb-bba4-a4c5d11d28f7",
               "label": null,
               "isExecuted": false,
-              "uuid": "1b174cf6-8bd2-40af-b479-acc32eec407b"
+              "uuid": "81ae23df-3f47-40c3-a073-5acc0a39028a"
             }
           ],
+          "groups": [],
           "priority": null,
-          "uuid": "0abc2445-cf11-45fc-863c-c7dae89b43d2",
-          "id": 4585,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.81106,
-          "modifyUser": "/api/3/people/3451141c-bac6-467c-8d72-85e0fab569ce",
-          "modifyDate": 1657284322.081089,
+          "uuid": "e02a2669-6396-46ad-bb07-b27a5f5004e7",
+          "id": 2327,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -417,2188 +3403,27 @@
         {
           "@type": "Workflow",
           "triggerLimit": null,
-          "name": "> IBM QRadar > Fetch",
-          "aliasName": null,
-          "tag": "#qradar #fetch #dataingestion",
-          "description": "This playbook fetches the Offenses.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1657518685,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/9ad8a0ff-ad4c-46ca-8c6a-c253c673547a",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Calculate QRadar Epoch Time",
-              "description": null,
-              "arguments": {
-                "qradar_epoch": "{{ ( arrow.get(vars.curr_timestamp).shift(minutes=-vars.time_diff_min).int_timestamp) * 1000}}"
-              },
-              "status": null,
-              "top": "760",
-              "left": "680",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "0c594fee-eb79-49c4-b2de-7a5344fb3535"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Configuration",
-              "description": null,
-              "arguments": {
-                "macro_name": "{{vars['audit_info']['cyops_playbook_iri'].split('/')[-1].replace('-','_')}}",
-                "filter_string": "status=\"OPEN\"",
-                "qradar_timezone": "UTC",
-                "event_record_limit": "50",
-                "Pull_Sample_Offense_in_Past_X_Minutes": "10"
-              },
-              "status": null,
-              "top": "180",
-              "left": "80",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "0eb20961-72b5-43ed-ab8b-0f7969e74420"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Offenses",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "filter_string": "{{vars.filter_string}} and (start_time > '{{vars.qradar_epoch}}' or last_updated_time > '{{vars.qradar_epoch}}' )"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "get_offenses",
-                "operationTitle": "Get Offenses from QRadar",
-                "step_variables": {
-                  "all_offenses": "{{ vars.result.data }}"
-                }
-              },
-              "status": null,
-              "top": "860",
-              "left": "840",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "123aa4a6-84f8-45df-b02b-97e12e3575a9"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Set Time Configuration",
-              "description": null,
-              "arguments": {
-                "curr_timestamp": "{{arrow.utcnow().int_timestamp}}",
-                "last_pull_time": "{% if (vars.steps.Get_Macro_Value.data[\"hydra:member\"] | length) > 0 and vars.steps.Get_Macro_Value.data[\"hydra:member\"][0].value | int  > 0 %}{{vars.steps.Get_Macro_Value.data[\"hydra:member\"][0].value}}{% else %}{{ (arrow.utcnow().int_timestamp) - (vars.Pull_Sample_Offense_in_Past_X_Minutes| int)  *60 }}{% endif %}"
-              },
-              "status": null,
-              "top": "520",
-              "left": "480",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "2c655558-0d8a-4c63-a892-7d2f8a281c09"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Update Offenses With IP Details",
-              "description": null,
-              "arguments": {
-                "_dummy_for_src_addrs": "{% for each_offense in vars.all_offenses %}\n {% set offense_src_ips = [] %}\n {% for each_ip in vars.steps.Get_Source_Address_Details.data %}\n {% if each_ip.id in each_offense.source_address_ids %}\n {% set _temp =  offense_src_ips.append(each_ip) %}\n {% endif %}\n{% endfor %}\n{% set _temp2 = each_offense.update({\"source_address_details\": offense_src_ips}) %}\n {% endfor %}",
-                "_dummy_for_dest_addrs": "{% for each_offense in vars.all_offenses %}\n {% set offense_dest_ips = [] %}\n {% for each_ip in vars.steps.Get_Destination_Address_Details.data %}\n {% if each_ip.id in each_offense.local_destination_address_ids %}\n {% set _temp =  offense_dest_ips.append(each_ip) %}\n{% endif %}\n{% endfor %}\n{% set _temp2 = each_offense.update({\"destination_address_details\": offense_dest_ips}) %}\n {% endfor %}"
-              },
-              "status": null,
-              "top": "1320",
-              "left": "1040",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "48ced67d-46fe-477e-a543-b8d098cfec62"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Destination Address Details",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "when": "{{(vars.all_offenses | length > 0) and (vars.destinations_ips | length > 0)}}",
-                "config": "",
-                "params": {
-                  "destination_address_ids": "{{vars.destinations_ips}}"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "get_destination_ip",
-                "operationTitle": "Get Destination IP Addresses",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "1200",
-              "left": "1040",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "55ece40e-65d8-4545-a980-af5f040fba98"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Create Macro List",
-              "description": null,
-              "arguments": {
-                "macro_list": "[{\"macro_name\": \"QRadarLastOffensePullTime_{{vars.macro_name}}\" , \"macro_value\": 0, \"override\": false},{\"macro_name\": \"QRadarTimeZone_{{vars.macro_name}}\" , \"macro_value\": \"{{vars.qradar_timezone}}\", \"override\": true},{\"macro_name\": \"QRadarEventLimit_{{vars.macro_name}}\" , \"macro_value\": \"{{vars.event_record_limit}}\", \"override\": true}]"
-              },
-              "status": null,
-              "top": "280",
-              "left": "80",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "5f25e4fa-629c-45cc-a52e-c4644365e709"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Collect IP ids",
-              "description": null,
-              "arguments": {
-                "src_ips": "{{ vars.steps.Get_Offenses.data | json_query('[*].source_address_ids[]') }}",
-                "destinations_ips": "{{ vars.steps.Get_Offenses.data | json_query('[*].local_destination_address_ids[]') }}"
-              },
-              "status": null,
-              "top": "980",
-              "left": "840",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "72e112f1-4352-4c7a-b7ee-53b72430bcdf"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Calculate Diff in min",
-              "description": null,
-              "arguments": {
-                "time_diff_min": "{{ (vars.curr_timestamp - vars.last_pull_time) / 60 | round }}"
-              },
-              "status": null,
-              "top": "620",
-              "left": "680",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "73897d90-5ec2-4ac5-8b47-c9f31750df3d"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Set Result",
-              "description": null,
-              "arguments": {
-                "data": "{{vars.all_offenses}}",
-                "curr_timestamp": "{{vars.curr_timestamp}}",
-                "QRadarLimitMacro": "{{vars.macro_list[2].get(\"macro_value\")}}",
-                "QRadarPullTimeMacro": "{{vars.macro_list[0].get(\"macro_name\")}}",
-                "QRadarTimeZoneMacro": "{{vars.macro_list[1].get(\"macro_value\")}}"
-              },
-              "status": null,
-              "top": "1460",
-              "left": "1040",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "8ac65c82-5d9b-4ab5-b46a-b10da98fc83b"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "step_variables": {
-                  "input": {
-                    "params": []
-                  },
-                  "_configuration_schema": "[{\n\t\t\"title\": \"Search Query\",\n\t\t\"tooltip\": \"The Query to be run on QRadar to fetch offenses\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"text\",\n\t\t\"name\": \"filter_string\",\n\t\t\"value\": \"status=\\\"OPEN\\\"\"\n\t}, {\n\t\t\"title\": \"Pull Offenses in the last X minutes\",\n\t\t\"tooltip\": \"Limit the search query specified above to filter the offenses created or modified in the last X minutes\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"text\",\n\t\t\"name\": \"Pull_Sample_Offense_in_Past_X_Minutes\",\n\t\t\"value\": 10\n\n\t},\n\t{\n\t\t\"title\": \"Timezone of the QRadar server\",\n\t\t\"tooltip\": \"Required for the time conversion to pull events since the last X minutes for an offense\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"text\",\n\t\t\"name\": \"qradar_timezone\",\n\t\t\"value\": \"UTC\"\n\n\t},\n\t{\n\t\t\"title\": \"Event Record Limit\",\n\t\t\"tooltip\": \"Pull number of events for an offense\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"integer\",\n\t\t\"name\": \"event_record_limit\",\n\t\t\"value\": 50\n\t}\n]"
-                }
-              },
-              "status": null,
-              "top": "60",
-              "left": "80",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "uuid": "9ad8a0ff-ad4c-46ca-8c6a-c253c673547a"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Macro Value",
-              "description": null,
-              "arguments": {
-                "params": {
-                  "iri": "/api/wf/api/dynamic-variable/?name={{vars.macro_list[0].get(\"macro_name\")}}",
-                  "body": "",
-                  "method": "GET"
-                },
-                "version": "3.2.1",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "400",
-              "left": "480",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "uuid": "9db9dfe8-870e-4062-a32a-37f8363db301"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Environment Setup",
-              "description": null,
-              "arguments": {
-                "when": "{{vars.request.env_setup}}",
-                "for_each": {
-                  "item": "{{vars.macro_list}}",
-                  "__bulk": false,
-                  "parallel": true,
-                  "condition": ""
-                },
-                "arguments": {
-                  "QRadarMacroName": "{{vars.item.macro_name}}",
-                  "QRadarMacroValue": "{{vars.item.macro_value}}",
-                  "overrideIfNoMatch": "{{vars.item.override}}"
-                },
-                "apply_async": false,
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/159e8dee-32b3-4eef-9b29-d8acea484d36"
-              },
-              "status": null,
-              "top": "280",
-              "left": "480",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "uuid": "a8e6f06e-c952-4ebe-9fb2-41e04eced179"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Source Address Details",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "when": "{{(vars.all_offenses | length > 0) and (vars.src_ips | length > 0)}}",
-                "config": "",
-                "params": {
-                  "source_address_ids": "{{vars.src_ips}}"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "get_source_ip",
-                "operationTitle": "Get Source IP Addresses",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "1080",
-              "left": "1040",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "ececad13-f5f2-4dcd-847b-065cd2a34578"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Collect IP ids -> Get Source IP Details",
-              "targetStep": "/api/3/workflow_steps/ececad13-f5f2-4dcd-847b-065cd2a34578",
-              "sourceStep": "/api/3/workflow_steps/72e112f1-4352-4c7a-b7ee-53b72430bcdf",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "1c769df0-a565-4619-ab46-d6dc0983d341"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Set Time Configuration -> Calculate Diff in min",
-              "targetStep": "/api/3/workflow_steps/73897d90-5ec2-4ac5-8b47-c9f31750df3d",
-              "sourceStep": "/api/3/workflow_steps/2c655558-0d8a-4c63-a892-7d2f8a281c09",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "2c611703-99cc-4f74-b203-e5ce8c602dfc"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Create QRadar Last Offense Pull Time Macro -> Get Macro Value",
-              "targetStep": "/api/3/workflow_steps/9db9dfe8-870e-4062-a32a-37f8363db301",
-              "sourceStep": "/api/3/workflow_steps/a8e6f06e-c952-4ebe-9fb2-41e04eced179",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "3d1f95a4-99f7-4184-a668-e21314c9431d"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Configuration -> Copy of Configuration",
-              "targetStep": "/api/3/workflow_steps/5f25e4fa-629c-45cc-a52e-c4644365e709",
-              "sourceStep": "/api/3/workflow_steps/0eb20961-72b5-43ed-ab8b-0f7969e74420",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "4a2d216c-f37d-4bfb-8b59-0d7101d7940a"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Calculate QRadar Epoch Time -> Get Offenses",
-              "targetStep": "/api/3/workflow_steps/123aa4a6-84f8-45df-b02b-97e12e3575a9",
-              "sourceStep": "/api/3/workflow_steps/0c594fee-eb79-49c4-b2de-7a5344fb3535",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "4eebd60b-b4db-4c60-87f5-44afebd7703a"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Create Macro List -> Create QRadar Last Offense Pull Time Macro",
-              "targetStep": "/api/3/workflow_steps/a8e6f06e-c952-4ebe-9fb2-41e04eced179",
-              "sourceStep": "/api/3/workflow_steps/5f25e4fa-629c-45cc-a52e-c4644365e709",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "50fc6e76-30f9-4cb2-9f3a-50b4be02db59"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Calculate Diff in min -> Calculate QRadar Epoch Time",
-              "targetStep": "/api/3/workflow_steps/0c594fee-eb79-49c4-b2de-7a5344fb3535",
-              "sourceStep": "/api/3/workflow_steps/73897d90-5ec2-4ac5-8b47-c9f31750df3d",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "5c104931-de5d-4684-8f4f-397dc29ee598"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Update Offenses With IP Details -> Set Result",
-              "targetStep": "/api/3/workflow_steps/8ac65c82-5d9b-4ab5-b46a-b10da98fc83b",
-              "sourceStep": "/api/3/workflow_steps/48ced67d-46fe-477e-a543-b8d098cfec62",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "70d18d42-7f5a-4ab2-8b97-0a553216b5fe"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Offenses -> Collect IP ids",
-              "targetStep": "/api/3/workflow_steps/72e112f1-4352-4c7a-b7ee-53b72430bcdf",
-              "sourceStep": "/api/3/workflow_steps/123aa4a6-84f8-45df-b02b-97e12e3575a9",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "92d8817b-2f25-401f-a11a-3335caf738cf"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Configuration",
-              "targetStep": "/api/3/workflow_steps/0eb20961-72b5-43ed-ab8b-0f7969e74420",
-              "sourceStep": "/api/3/workflow_steps/9ad8a0ff-ad4c-46ca-8c6a-c253c673547a",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "97aa4447-8165-423d-8de8-311d22e1c1b1"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Macro Value -> Set Time Configuration",
-              "targetStep": "/api/3/workflow_steps/2c655558-0d8a-4c63-a892-7d2f8a281c09",
-              "sourceStep": "/api/3/workflow_steps/9db9dfe8-870e-4062-a32a-37f8363db301",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "d7e4ec20-280e-4456-bcf4-b14842e90bbf"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Destination Address Details -> Update Offenses With IP Details",
-              "targetStep": "/api/3/workflow_steps/48ced67d-46fe-477e-a543-b8d098cfec62",
-              "sourceStep": "/api/3/workflow_steps/55ece40e-65d8-4545-a980-af5f040fba98",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "ea9c20de-9c80-456e-aa3f-9b45e180ac5a"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Source IP Details -> Get Destination Address Details",
-              "targetStep": "/api/3/workflow_steps/55ece40e-65d8-4545-a980-af5f040fba98",
-              "sourceStep": "/api/3/workflow_steps/ececad13-f5f2-4dcd-847b-065cd2a34578",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "ec85c421-29b7-4561-be59-9cbf0954a6db"
-            }
-          ],
-          "priority": null,
-          "uuid": "125d079a-13f1-44fa-a75f-4294aafc643b",
-          "id": 4586,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.811823,
-          "modifyUser": "/api/3/people/3451141c-bac6-467c-8d72-85e0fab569ce",
-          "modifyDate": 1657518678.667567,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "dataingestion",
-            "fetch",
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Run Ariel Query",
+          "name": "Get Table Elements",
           "aliasName": null,
           "tag": "#qradar",
-          "description": "This playbook demonstrate Make an Ariel Query To QRadar Operation",
+          "description": "Get records details of a reference table defined by name",
           "isActive": false,
           "debug": false,
           "singleRecordExecution": false,
           "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
+          "lastModifyDate": 1672638498,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
           "versions": [],
-          "triggerStep": "/api/3/workflow_steps/2116f5ce-136f-4bcb-b2b6-cc5c6e8201a0",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "79833840-153e-4deb-8034-81abc4cfaba2",
-                "title": "IBM QRadar: Run Ariel Query",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "60",
-              "left": "86",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "2116f5ce-136f-4bcb-b2b6-cc5c6e8201a0"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Search Result",
-              "description": null,
-              "arguments": {
-                "resultData": "{{vars.result}}"
-              },
-              "status": null,
-              "top": "271",
-              "left": "448",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "cc21b3ef-2f38-4055-b443-2340d73d60f9"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Run Ariel Query",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "search_string": "show tables"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "query_qradar",
-                "operationTitle": "Make an Ariel Query to QRadar",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "147",
-              "left": "220",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "e26041d9-a8a1-449d-a870-4d508588b58f"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Run Ariel Query -> SearchResult",
-              "targetStep": "/api/3/workflow_steps/cc21b3ef-2f38-4055-b443-2340d73d60f9",
-              "sourceStep": "/api/3/workflow_steps/e26041d9-a8a1-449d-a870-4d508588b58f",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "4902679c-8f4c-4b22-96b1-af75c7190c13"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Run Ariel Query",
-              "targetStep": "/api/3/workflow_steps/e26041d9-a8a1-449d-a870-4d508588b58f",
-              "sourceStep": "/api/3/workflow_steps/2116f5ce-136f-4bcb-b2b6-cc5c6e8201a0",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "8ea5ed49-820c-411b-9b3d-4ffcc9023b83"
-            }
-          ],
-          "priority": null,
-          "uuid": "14c16ccd-369f-4c27-a541-65381eefc190",
-          "id": 4587,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.812791,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.812791,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": ">> IBM QRadar > Init Macros",
-          "aliasName": null,
-          "tag": "#qradar #dataingestion",
-          "description": "This playbook creates IBM QRadar macros if not exist.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [
-            "QRadarMacroName",
-            "QRadarMacroValue",
-            "overrideIfNoMatch"
-          ],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/750e983a-c444-4cf0-b0ab-cf326f48bbfa",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get QRadar Macros",
-              "description": null,
-              "arguments": {
-                "name": "Utilities",
-                "params": {
-                  "iri": "/api/wf/api/dynamic-variable/?format=json&name={{vars.QRadarMacroName}}",
-                  "body": "",
-                  "method": "GET"
-                },
-                "version": "2.5.0",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "CyOPs: Make CyOPs API Call",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "120",
-              "left": "171",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "294c5a66-d2c4-475e-8244-531971aeff7f"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "step_variables": {
-                  "input": {
-                    "params": {
-                      "QRadarMacroName": "{{ vars.QRadarMacroName }}",
-                      "QRadarMacroValue": "{{ vars.QRadarMacroValue }}",
-                      "overrideIfNoMatch": "{{ vars.overrideIfNoMatch }}"
-                    }
-                  }
-                }
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "uuid": "750e983a-c444-4cf0-b0ab-cf326f48bbfa"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Update Macro If Required",
-              "description": null,
-              "arguments": {
-                "when": "{{(vars.input.params.overrideIfNoMatch  == true) and (vars.macroExistingRecord.value != vars.QRadarMacroValue)}}",
-                "params": {
-                  "iri": "/api/wf/api/dynamic-variable/{{ vars.macroExistingRecord.id }}/",
-                  "body": "{ 'name': '{{vars.QRadarMacroName}}'   , 'value': '{{vars.QRadarMacroValue}}' }",
-                  "method": "PUT"
-                },
-                "version": "2.7.0",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "CyOPs: Make CyOPs API Call",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "147",
-              "left": "952",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "uuid": "8c4fa95c-544b-4ec0-b9f9-792040fe77c0"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "QRadar Macro Exists",
-              "description": null,
-              "arguments": {
-                "conditions": [
-                  {
-                    "option": "Not Exist",
-                    "step_iri": "/api/3/workflow_steps/fb844f9e-7a8b-4de3-bcf4-a82321234151",
-                    "condition": "{{ vars.steps.Get_QRadar_Macros.data['hydra:totalItems'] == 0 }}"
-                  },
-                  {
-                    "option": "Exist",
-                    "default": true,
-                    "step_iri": "/api/3/workflow_steps/ceaf2781-7e4c-42c1-af3e-7617a864daa8"
-                  }
-                ]
-              },
-              "status": null,
-              "top": "228",
-              "left": "320",
-              "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-              "uuid": "becd0217-79e3-4550-a4a9-ddb54f785dcd"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Fetch Macro Current Value",
-              "description": null,
-              "arguments": {
-                "macroExistingRecord": "{{vars.steps.Get_QRadar_Macros.data['hydra:member'][0]}}"
-              },
-              "status": null,
-              "top": "147",
-              "left": "651",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "ceaf2781-7e4c-42c1-af3e-7617a864daa8"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Create IBM QRadar Macro",
-              "description": null,
-              "arguments": {
-                "params": {
-                  "iri": "/api/wf/api/dynamic-variable/?format=json",
-                  "body": "{ 'name': '{{vars.QRadarMacroName}}'   , 'value': '{{vars.QRadarMacroValue}}' }",
-                  "method": "POST"
-                },
-                "version": "2.5.0",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "CyOPs: Make CyOPs API Call",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "306",
-              "left": "651",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "uuid": "fb844f9e-7a8b-4de3-bcf4-a82321234151"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Check IBM QRadar Macro -> Create IBM QRadar Macro",
-              "targetStep": "/api/3/workflow_steps/fb844f9e-7a8b-4de3-bcf4-a82321234151",
-              "sourceStep": "/api/3/workflow_steps/becd0217-79e3-4550-a4a9-ddb54f785dcd",
-              "label": "Not Exist",
-              "isExecuted": false,
-              "uuid": "1d0e5ab9-0999-4bf6-aaa2-693afb0a21b1"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Fetch Macro Current Value -> Update Macro If Required",
-              "targetStep": "/api/3/workflow_steps/8c4fa95c-544b-4ec0-b9f9-792040fe77c0",
-              "sourceStep": "/api/3/workflow_steps/ceaf2781-7e4c-42c1-af3e-7617a864daa8",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "669fb159-8505-425a-b5c4-1959a1a6bb53"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get All Macros -> Check IBM QRadar Macro",
-              "targetStep": "/api/3/workflow_steps/becd0217-79e3-4550-a4a9-ddb54f785dcd",
-              "sourceStep": "/api/3/workflow_steps/294c5a66-d2c4-475e-8244-531971aeff7f",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "9197a4b1-c99d-4299-a96e-6c7d5b7cccca"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Get All Macros",
-              "targetStep": "/api/3/workflow_steps/294c5a66-d2c4-475e-8244-531971aeff7f",
-              "sourceStep": "/api/3/workflow_steps/750e983a-c444-4cf0-b0ab-cf326f48bbfa",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "b7194a25-1f13-4c4c-85e2-f92b4cb70dc1"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "QRadar Macro Exists -> Fetch Macro Current Value",
-              "targetStep": "/api/3/workflow_steps/ceaf2781-7e4c-42c1-af3e-7617a864daa8",
-              "sourceStep": "/api/3/workflow_steps/becd0217-79e3-4550-a4a9-ddb54f785dcd",
-              "label": "Exist",
-              "isExecuted": false,
-              "uuid": "b82fea57-244a-4bf4-b751-611814a089e6"
-            }
-          ],
-          "priority": null,
-          "uuid": "159e8dee-32b3-4eef-9b29-d8acea484d36",
-          "id": 4588,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.813438,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.813438,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "dataingestion",
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Offense Notes",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "Retrieve a list of notes for an offense from QRadar.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/8d8fcdff-c7ce-46cb-b5f8-f50edaa6f8a8",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Offense Notes",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "offense_id": "286"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "get_notes",
-                "operationTitle": "Get Offense Notes",
-                "step_variables": {
-                  "output_data": "{{vars.result.data}}"
-                }
-              },
-              "status": null,
-              "top": "113",
-              "left": "200",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "01c44335-60aa-4cfa-b78d-8f34921c2987"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "14e8b7ac-3156-4b1c-b3fc-07ca5112edff",
-                "title": "IBM QRadar: Get Offense Notes",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "200",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "8d8fcdff-c7ce-46cb-b5f8-f50edaa6f8a8"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Get Reasons",
-              "targetStep": "/api/3/workflow_steps/01c44335-60aa-4cfa-b78d-8f34921c2987",
-              "sourceStep": "/api/3/workflow_steps/8d8fcdff-c7ce-46cb-b5f8-f50edaa6f8a8",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "dc9628dd-d3a9-41b0-8886-7d69982a2795"
-            }
-          ],
-          "priority": null,
-          "uuid": "211e816f-3d3c-40f3-a929-a768963b7750",
-          "id": 4589,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.814143,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.814143,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Create Note",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "Create a note on specified offense id on QRadar.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/420f7f4c-6939-4d6d-b873-d09dd2c44eac",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "64d91c70-f421-4026-b06e-9b2e660322bb",
-                "title": "IBM QRadar: Create Note",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "200",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "420f7f4c-6939-4d6d-b873-d09dd2c44eac"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Create Note",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "offense_id": "286",
-                  "closure_note": "Add note from FortiSOAR."
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "add_notes",
-                "operationTitle": "Create Note",
-                "step_variables": {
-                  "output_data": "{{vars.result.data}}"
-                }
-              },
-              "status": null,
-              "top": "114",
-              "left": "200",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "430b0134-f964-4af2-b063-467eb0a13454"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Get Reasons",
-              "targetStep": "/api/3/workflow_steps/430b0134-f964-4af2-b063-467eb0a13454",
-              "sourceStep": "/api/3/workflow_steps/420f7f4c-6939-4d6d-b873-d09dd2c44eac",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "293779bf-c1c1-490b-b03c-f4cc8c0ab081"
-            }
-          ],
-          "priority": null,
-          "uuid": "22fa8308-f0df-4ca7-aef3-c778943c8795",
-          "id": 4590,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.81475,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.81475,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Source IP Addresses",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "Get Details for the given source IP Address Ids",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/4e07b653-2d62-4e04-a1cd-eec6ff8b643d",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Source IP Addresses",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "source_address_ids": "[4]"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "get_source_ip",
-                "operationTitle": "Get Source IP Addresses",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "165",
-              "left": "125",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "084ccd28-7ad1-49f6-a1af-0b0ec73c939b"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Alerts",
-              "description": null,
-              "arguments": {
-                "route": "bc69b525-b45c-4e42-9002-c74fdc945d63",
-                "title": "IBM QRadar: Get Source IP Addresses",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "30",
-              "left": "125",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "4e07b653-2d62-4e04-a1cd-eec6ff8b643d"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Alerts -> Get Source IP Addresses",
-              "targetStep": "/api/3/workflow_steps/084ccd28-7ad1-49f6-a1af-0b0ec73c939b",
-              "sourceStep": "/api/3/workflow_steps/4e07b653-2d62-4e04-a1cd-eec6ff8b643d",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "8bfe73d0-66e3-46f8-8bcc-9d0d9395223c"
-            }
-          ],
-          "priority": null,
-          "uuid": "4bc511e2-0e54-49e6-a23f-7cb525ee5941",
-          "id": 4591,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.815294,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.815294,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Events Related to an Offense",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "Get Events Related to an Offense",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/33069f37-6286-435f-9c64-2d4654778ab3",
+          "triggerStep": "/api/3/workflow_steps/0756f0c2-ed7d-4094-895c-5053585842eb",
           "steps": [
             {
               "@type": "WorkflowStep",
               "name": "Alerts",
               "description": null,
               "arguments": {
-                "route": "7ad32b48-ce7b-431c-bac4-c809f135f6ed",
-                "title": "IBM QRadar: Get Events Related to an Offense",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "33069f37-6286-435f-9c64-2d4654778ab3"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Events Related to an Offense",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "offense_id": "41",
-                  "start_time": "2019-06-03T18:30:00.000Z",
-                  "max_results": 100,
-                  "last_updated_time": "2019-07-02T18:30:00.000Z"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "get_events_related_to_offense",
-                "operationTitle": "Get Events Related to an Offense",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "107",
-              "left": "200",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "4d9809c3-f8ae-4652-b33d-5968fc6172c4"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Alerts -> Get Events Related to an Offense",
-              "targetStep": "/api/3/workflow_steps/4d9809c3-f8ae-4652-b33d-5968fc6172c4",
-              "sourceStep": "/api/3/workflow_steps/33069f37-6286-435f-9c64-2d4654778ab3",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "9a60eee1-987e-4669-b349-7f1152f80251"
-            }
-          ],
-          "priority": null,
-          "uuid": "63feb438-821e-4f2a-8980-d57708b88559",
-          "id": 4592,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.815855,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.815855,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Offense Type",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "This playbook demonstrate Get Offense Type. Offense Type can be used with Get Offense operation as a filter",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/3b0c2051-ce6c-4822-8468-4b51209e1a63",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "b37b0ce8-fa11-4a76-8fde-7cb6a8992414",
-                "title": "IBM QRadar: Get Offense Type",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "30",
-              "left": "108",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "3b0c2051-ce6c-4822-8468-4b51209e1a63"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Offenses Type",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": [],
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "get_offense_type",
-                "operationTitle": "Get Offense Types",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "135",
-              "left": "250",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "8092d633-7277-4301-91cc-745b9db05d14"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Get Offenses Type",
-              "targetStep": "/api/3/workflow_steps/8092d633-7277-4301-91cc-745b9db05d14",
-              "sourceStep": "/api/3/workflow_steps/3b0c2051-ce6c-4822-8468-4b51209e1a63",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "a3fc62f0-15d0-42ef-8754-b51c099a8af6"
-            }
-          ],
-          "priority": null,
-          "uuid": "6994be04-bc37-4be6-b47a-d5f82a05728b",
-          "id": 4593,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.816383,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.816383,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Invoke QRadar REST API",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "This playbook demonstrate Invoke QRadar API operation",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/62a0b5ed-96d2-426d-bc18-acde94db8479",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Invoke QRadar API",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "method": "GET",
-                  "headers": "{\n  \"Version\": \"6.0\",\n  \"Accept\": \"application/json\",\n  \"Content-Type\": \"application/json\"\n}",
-                  "endpoint": "/siem/offenses/13",
-                  "request_parameters": "{}"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "invoke_api",
-                "operationTitle": "Invoke QRadar API",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "128",
-              "left": "218",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "1157ca39-b283-4740-8474-057b3afe65cb"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "1581cd2d-f0f2-4d2c-a987-5794a541646a",
-                "title": "IBM QRadar: Invoke QRadar REST API",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "40",
-              "left": "71",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "62a0b5ed-96d2-426d-bc18-acde94db8479"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Invoke QRadar API",
-              "targetStep": "/api/3/workflow_steps/1157ca39-b283-4740-8474-057b3afe65cb",
-              "sourceStep": "/api/3/workflow_steps/62a0b5ed-96d2-426d-bc18-acde94db8479",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "ed4e3489-0798-48e7-ae5d-daf9e8c911ea"
-            }
-          ],
-          "priority": null,
-          "uuid": "7c735b54-2e7b-4735-a27c-c210094b1ca0",
-          "id": 4594,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.816937,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.816937,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "API - Push Offense From QRadar",
-          "aliasName": null,
-          "tag": "#qradar app",
-          "description": "This playbook demonstrate the QRadar App. You need have QRadar CyberSponse App installed on QRadar.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/719a5136-bfe7-4404-8980-a37760e7f7c3",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "qradar",
-                "authentication_methods": [
-                  ""
-                ]
-              },
-              "status": null,
-              "top": "53",
-              "left": "234",
-              "stepType": "/api/3/workflow_step_types/df26c7a2-4166-4ca5-91e5-548e24c01b5f",
-              "uuid": "719a5136-bfe7-4404-8980-a37760e7f7c3"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Offense Details",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "filter_string": "id={{ vars.request.data.Offense_ID }}"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "get_offenses",
-                "operationTitle": "Get Offenses from QRadar",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "160",
-              "left": "400",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "82a0e2f5-2bd9-4fa3-9cd2-511844f03b99"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Get Offense Details",
-              "targetStep": "/api/3/workflow_steps/82a0e2f5-2bd9-4fa3-9cd2-511844f03b99",
-              "sourceStep": "/api/3/workflow_steps/719a5136-bfe7-4404-8980-a37760e7f7c3",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "bf687be1-6d02-424e-9045-544715001703"
-            }
-          ],
-          "priority": null,
-          "uuid": "9127d727-d722-48a9-99d6-86e34e9931ed",
-          "id": 4596,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.818207,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.818207,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar app"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Manipulate Reference Set Content",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "Add, retrieve or delete the content from specified reference set",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/b75e1af3-e287-4457-a2d2-4df52217e433",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Manipulate Reference Set Content",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "name": "FortiSOAR RFC",
-                  "method": "Retrieves Value"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "handle_reference_set_value",
-                "operationTitle": "Manipulate Reference Set Content",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "152",
-              "left": "253",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "a6e87616-393d-43d5-b348-3bfaf4fe1c55"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Alerts",
-              "description": null,
-              "arguments": {
-                "route": "d09802ae-f975-4c61-b669-6554bc2df7eb",
-                "title": "IBM QRadar: Manipulate Reference Set Content",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "80",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "b75e1af3-e287-4457-a2d2-4df52217e433"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Alerts -> Manipulate Reference Set Content",
-              "targetStep": "/api/3/workflow_steps/a6e87616-393d-43d5-b348-3bfaf4fe1c55",
-              "sourceStep": "/api/3/workflow_steps/b75e1af3-e287-4457-a2d2-4df52217e433",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "9ae81bf2-fbd7-4ae7-b5ed-fc8eefcbd39e"
-            }
-          ],
-          "priority": null,
-          "uuid": "9d77bf32-a65d-4074-b8b2-651a6214325f",
-          "id": 4597,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.818772,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.818772,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "IBM QRadar > Post Create Alert > Fetch Events",
-          "aliasName": null,
-          "tag": "#qradar #dataingestion",
-          "description": "Fetch events, source and destination ip address of an offense.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [
-            "qradar_timezone",
-            "qradar_event_limit",
-            "alertRecord"
-          ],
-          "synchronous": false,
-          "lastModifyDate": 1657284391,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/cfab1be9-0e61-493b-9629-cf196f21dc95",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Fetch Events For an Offense",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "search_string": "SELECT  {{vars.event_query_params}} FROM EVENTS WHERE INOFFENSE({{vars.alertSourceData.offense_data['id']}}) ORDER BY starttime DESC LIMIT {{vars.event_record_limit}} START  '{{vars.offense_start_time}}' STOP '{{vars.current_time}}'"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "query_qradar",
-                "operationTitle": "Make an Ariel Query to QRadar",
-                "step_variables": {
-                  "offense_details": "{\n\"offense_data\": {{vars.alertSourceData.offense_data}},\n\"events_data\": {{vars.result.data.events}}\n}"
-                }
-              },
-              "status": null,
-              "top": "271",
-              "left": "649",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "43ed2c03-23ea-4279-a43f-0288113214f8"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Set Source Data",
-              "description": null,
-              "arguments": {
-                "alertSourceData": "{{vars.input.params.alertRecord.sourcedata | from_json}}"
-              },
-              "status": null,
-              "top": "111",
-              "left": "189",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "a6d9b8a3-95bc-4311-b0cf-c66a4161d8da"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Configuration",
-              "description": null,
-              "arguments": {
-                "current_time": "{{arrow.now(vars.input.params['qradar_timezone']).format('YYYY-MM-DD HH:mm:ss')}}",
-                "event_query_params": "starttime,sourceip,destinationip,username,QIDNAME(qid) as 'Event_Name',CATEGORYNAME(category) AS 'Category_Name',LOGSOURCENAME(logsourceid) as 'Log_Source'",
-                "event_record_limit": "{% if vars.input.params['qradar_event_limit']%}{{vars.input.params['qradar_event_limit']}}{% else %}50{% endif %}",
-                "offense_start_time": "{{arrow.get((vars.alertSourceData.offense_data.start_time | int )/1000).to(vars.input.params['qradar_timezone']).format('YYYY-MM-DD HH:mm:ss')}}"
-              },
-              "status": null,
-              "top": "200",
-              "left": "340",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "c6d28001-f1a4-4110-af03-51c962f97c68"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Update Alert",
-              "description": null,
-              "arguments": {
-                "resource": {
-                  "sourcedata": "{{vars.offense_details | toJSON }}"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.params.alertRecord['@id']}}",
-                "__recommend": [],
-                "collectionType": "/api/3/alerts",
-                "fieldOperation": {
-                  "recordTags": "Append"
-                },
-                "step_variables": []
-              },
-              "status": null,
-              "top": "353",
-              "left": "840",
-              "stepType": "/api/3/workflow_step_types/b593663d-7d13-40ce-a3a3-96dece928722",
-              "uuid": "c83b8d69-d683-47c4-b63f-c51623f17e43"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "step_variables": {
-                  "input": {
-                    "params": []
-                  }
-                }
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "uuid": "cfab1be9-0e61-493b-9629-cf196f21dc95"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Set Source Data",
-              "targetStep": "/api/3/workflow_steps/a6d9b8a3-95bc-4311-b0cf-c66a4161d8da",
-              "sourceStep": "/api/3/workflow_steps/cfab1be9-0e61-493b-9629-cf196f21dc95",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "8aa4ddbc-a21c-40a8-ab53-39c2a320c638"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Set Source Data -> Configuration",
-              "targetStep": "/api/3/workflow_steps/c6d28001-f1a4-4110-af03-51c962f97c68",
-              "sourceStep": "/api/3/workflow_steps/a6d9b8a3-95bc-4311-b0cf-c66a4161d8da",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "63543482-f6c2-4023-baab-323c799f73a2"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Configuration -> Fetch Events For an Offense",
-              "targetStep": "/api/3/workflow_steps/43ed2c03-23ea-4279-a43f-0288113214f8",
-              "sourceStep": "/api/3/workflow_steps/c6d28001-f1a4-4110-af03-51c962f97c68",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "960e36d5-aab9-41a2-b2e0-9a4e5cb3cb42"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Fetch Events For an Offense -> Update Alert",
-              "targetStep": "/api/3/workflow_steps/c83b8d69-d683-47c4-b63f-c51623f17e43",
-              "sourceStep": "/api/3/workflow_steps/43ed2c03-23ea-4279-a43f-0288113214f8",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "a116765d-533a-4935-a70b-f8fcac2f621f"
-            }
-          ],
-          "priority": null,
-          "uuid": "a0f9a5b4-c8d9-418c-a703-4acb02066346",
-          "id": 4598,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.819362,
-          "modifyUser": "/api/3/people/3451141c-bac6-467c-8d72-85e0fab569ce",
-          "modifyDate": 1657284385.683855,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "dataingestion",
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Close QRadar Offenses",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "This playbook demonstrate Get Offense Closing Reasons Operation.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/cb265745-55a3-4999-ab37-016a770db348",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Found a matching reason",
-              "description": null,
-              "arguments": {
-                "conditions": [
-                  {
-                    "step_iri": "/api/3/workflow_steps/b7966a0c-ccad-438d-aaa9-78545ba12d77",
-                    "condition": "{{ vars.reason_id_list is defined and vars.reason_id_list|length > 0 }}"
-                  },
-                  {
-                    "default": true,
-                    "step_iri": "/api/3/workflow_steps/b1e11aea-b8eb-49b9-8902-a55733936077"
-                  }
-                ]
-              },
-              "status": null,
-              "top": "340",
-              "left": "200",
-              "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-              "uuid": "0da8ac19-b85b-4122-8ef7-34bc22c84e8f"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Check Reason Ids",
-              "description": null,
-              "arguments": {
-                "reason_id_list": "{{ vars.result.data| selectattr(\"text\", \"equalto\", \"Policy Violation\")|list }}"
-              },
-              "status": null,
-              "top": "234",
-              "left": "200",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "2080a109-2ae6-438a-a765-bc30b9796867"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Reasons",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": [],
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "get_closing_reasons",
-                "operationTitle": "Get Offense Closing Reasons",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "113",
-              "left": "200",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "3dae073e-48a2-496d-a475-b1e1d59360d1"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Do Nothing",
-              "description": null,
-              "arguments": {
-                "params": [],
-                "version": "2.4.1",
-                "connector": "cyops_utilities",
-                "operation": "no_op",
-                "operationTitle": "Utils: No Operation",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "475",
-              "left": "47",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "uuid": "b1e11aea-b8eb-49b9-8902-a55733936077"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Set Reason Id",
-              "description": null,
-              "arguments": {
-                "reason_id": "{{ vars.reason_id_list [0]['id'] }}"
-              },
-              "status": null,
-              "top": "480",
-              "left": "380",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "b7966a0c-ccad-438d-aaa9-78545ba12d77"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "ede2b655-8557-49de-9a09-a4263e007ee7",
-                "title": "IBM QRadar: Close QRadar Offense",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": false,
-                "singleRecordExecution": true
-              },
-              "status": null,
-              "top": "20",
-              "left": "200",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "cb265745-55a3-4999-ab37-016a770db348"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Close Off",
-              "description": null,
-              "arguments": {
-                "for_each": {
-                  "item": "{{ vars.request.data.records }}",
-                  "condition": ""
-                },
-                "arguments": {
-                  "reasonID": "{{vars.reason_id}}",
-                  "offenseID": "{{vars.item}}"
-                },
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/e5f0e962-7563-4946-abb7-3cd2c9abe871"
-              },
-              "status": null,
-              "top": "614",
-              "left": "420",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "uuid": "f6b015d1-d1e5-49e9-ae7f-3f8fe0ddd596"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Set Reason Id -> Close Off",
-              "targetStep": "/api/3/workflow_steps/f6b015d1-d1e5-49e9-ae7f-3f8fe0ddd596",
-              "sourceStep": "/api/3/workflow_steps/b7966a0c-ccad-438d-aaa9-78545ba12d77",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "5b10b09a-e7c8-4f22-8101-993833c93080"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Found a matching reason -> yay",
-              "targetStep": "/api/3/workflow_steps/b7966a0c-ccad-438d-aaa9-78545ba12d77",
-              "sourceStep": "/api/3/workflow_steps/0da8ac19-b85b-4122-8ef7-34bc22c84e8f",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "6b55340d-1b2b-4300-884f-5ce997d683a5"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Found a matching reason -> Do Nothing",
-              "targetStep": "/api/3/workflow_steps/b1e11aea-b8eb-49b9-8902-a55733936077",
-              "sourceStep": "/api/3/workflow_steps/0da8ac19-b85b-4122-8ef7-34bc22c84e8f",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "7a54d5ad-db08-4f5d-bf93-524f8a2c5857"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Set Reason Id -> Found a matching reason",
-              "targetStep": "/api/3/workflow_steps/0da8ac19-b85b-4122-8ef7-34bc22c84e8f",
-              "sourceStep": "/api/3/workflow_steps/2080a109-2ae6-438a-a765-bc30b9796867",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "8d5ed686-1861-4ded-a78a-4f58b4f9236f"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Reasons -> Check Reason Ids",
-              "targetStep": "/api/3/workflow_steps/2080a109-2ae6-438a-a765-bc30b9796867",
-              "sourceStep": "/api/3/workflow_steps/3dae073e-48a2-496d-a475-b1e1d59360d1",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "95004a7c-5772-4738-94b0-950e5171899e"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Get Reasons",
-              "targetStep": "/api/3/workflow_steps/3dae073e-48a2-496d-a475-b1e1d59360d1",
-              "sourceStep": "/api/3/workflow_steps/cb265745-55a3-4999-ab37-016a770db348",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "a7c6f74b-d44d-42f6-82ad-9e7c81e0c0cb"
-            }
-          ],
-          "priority": null,
-          "uuid": "a5544a1b-8580-450d-9b85-9ef824c6e0e7",
-          "id": 4599,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.820018,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.820018,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Offenses",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "Get Offenses from QRadar.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1657518837,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/688f13f7-e086-4b0b-b78e-6cc0ec035c3d",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Offenses",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "filter_string": "status=\"OPEN\""
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "get_offenses",
-                "operationTitle": "Get Offenses from QRadar",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "165",
-              "left": "125",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "21cd0e9d-815f-4cd5-9de9-90c6f02d75eb"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "9a6444b0-8c61-414b-bf2e-ba848d5c9888",
-                "title": "IBM QRadar: Get Offenses",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "30",
-              "left": "125",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "688f13f7-e086-4b0b-b78e-6cc0ec035c3d"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Get Offenses",
-              "targetStep": "/api/3/workflow_steps/21cd0e9d-815f-4cd5-9de9-90c6f02d75eb",
-              "sourceStep": "/api/3/workflow_steps/688f13f7-e086-4b0b-b78e-6cc0ec035c3d",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "b1b3b5f4-6873-44ab-a228-c96eb430abe2"
-            }
-          ],
-          "priority": null,
-          "uuid": "cc310faa-bf20-4450-aaba-a9cf26fc358c",
-          "id": 4600,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.820741,
-          "modifyUser": "/api/3/people/3451141c-bac6-467c-8d72-85e0fab569ce",
-          "modifyDate": 1657518830.635925,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "> Close Offense",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "This playbook is continuation of sample playbook for Operation- Get Offense Closing Reasons",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [
-            "offenseID",
-            "reasonID"
-          ],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/c5120425-36fc-4593-8c6f-6a700e431f64",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "step_variables": {
-                  "input": {
-                    "params": {
-                      "reasonID": "{{ vars.reasonID }}",
-                      "offenseID": "{{ vars.offenseID }}"
-                    }
-                  }
-                }
-              },
-              "status": null,
-              "top": "40",
-              "left": "240",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "uuid": "c5120425-36fc-4593-8c6f-6a700e431f64"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Close Offense",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "offense_id": "{{ vars.offense_id }}",
-                  "closure_note": "",
-                  "offense_close_id": "{{ vars.reason_id }}"
-                },
-                "version": "1.5.1",
-                "connector": "qradar",
-                "operation": "close_offense",
-                "operationTitle": "Close Offense",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "260",
-              "left": "240",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "deafb24c-f772-4c46-8095-94ea02c642ad"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Set Offense Id",
-              "description": null,
-              "arguments": {
-                "reason_id": "{{vars.reasonID}}",
-                "offense_id": "{{vars.offenseID.sourceId}}"
-              },
-              "status": null,
-              "top": "149",
-              "left": "240",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "ec1daee2-b0e4-4ade-9eb1-76f30057ccad"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Set Offense Id -> Close",
-              "targetStep": "/api/3/workflow_steps/deafb24c-f772-4c46-8095-94ea02c642ad",
-              "sourceStep": "/api/3/workflow_steps/ec1daee2-b0e4-4ade-9eb1-76f30057ccad",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "367b74c5-a3a7-48ba-9d68-3e51f20c96f5"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Set Offense Id",
-              "targetStep": "/api/3/workflow_steps/ec1daee2-b0e4-4ade-9eb1-76f30057ccad",
-              "sourceStep": "/api/3/workflow_steps/c5120425-36fc-4593-8c6f-6a700e431f64",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "6e5183a3-2ccc-4e40-b4cc-44f9813bd779"
-            }
-          ],
-          "priority": null,
-          "uuid": "e5f0e962-7563-4946-abb7-3cd2c9abe871",
-          "id": 4601,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.821272,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.821272,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Destination IP Addresses",
-          "aliasName": null,
-          "tag": "#qradar",
-          "description": "Get Details for the given destination IP Address Ids",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1655276892,
-          "collection": "/api/3/workflow_collections/d129e8bf-32f1-410d-8807-343693acde71",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/410cfa73-ebf9-4362-979d-c9fdd8d56273",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Alerts",
-              "description": null,
-              "arguments": {
-                "route": "4d594c28-61c0-4a6a-a292-7e33422ad478",
+                "route": "fc8d9246-4dca-438b-a0d6-22dd1f8529c6",
                 "title": "IBM QRadar: Get Destination IP Addresses",
                 "resources": [
                   "alerts"
@@ -2622,52 +3447,253 @@
                 "singleRecordExecution": false
               },
               "status": null,
-              "top": "20",
-              "left": "20",
+              "top": "30",
+              "left": "125",
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "uuid": "410cfa73-ebf9-4362-979d-c9fdd8d56273"
+              "group": null,
+              "uuid": "0756f0c2-ed7d-4094-895c-5053585842eb"
             },
             {
               "@type": "WorkflowStep",
-              "name": "Get Destination IP Addresses",
+              "name": "Get Table Elements",
               "description": null,
               "arguments": {
                 "name": "IBM QRadar",
-                "config": "",
+                "config": "e524c682-01c1-416b-94bb-40aa2f2e6f55",
                 "params": {
-                  "destination_address_ids": "[10]"
+                  "path.name": "ip_whitelist",
+                  "max_results": 100
                 },
-                "version": "1.5.1",
+                "version": "1.6.0",
                 "connector": "qradar",
-                "operation": "get_destination_ip",
-                "operationTitle": "Get Destination IP Addresses",
+                "operation": "get_table_elements",
+                "operationTitle": "Get Table Element Details",
                 "step_variables": []
               },
               "status": null,
-              "top": "121",
-              "left": "163",
+              "top": "165",
+              "left": "125",
               "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "uuid": "9e4bedb2-b1ae-43c7-86d1-e2b62a2f0ce4"
+              "group": null,
+              "uuid": "2c2e5c40-ada4-4e42-8706-56660955a5a0"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
               "name": "Alerts -> Get Destination IP Addresses",
-              "targetStep": "/api/3/workflow_steps/9e4bedb2-b1ae-43c7-86d1-e2b62a2f0ce4",
-              "sourceStep": "/api/3/workflow_steps/410cfa73-ebf9-4362-979d-c9fdd8d56273",
+              "targetStep": "/api/3/workflow_steps/2c2e5c40-ada4-4e42-8706-56660955a5a0",
+              "sourceStep": "/api/3/workflow_steps/0756f0c2-ed7d-4094-895c-5053585842eb",
               "label": null,
               "isExecuted": false,
-              "uuid": "307c0b53-797b-4d97-ab8e-0bd200cb5fc5"
+              "uuid": "5546bc31-00b6-49f7-aa9c-4d81d831b9a6"
             }
           ],
+          "groups": [],
           "priority": null,
-          "uuid": "f06f0978-26e6-4b12-b694-3c51df268c2c",
-          "id": 4602,
-          "createUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "createDate": 1657270455.821856,
-          "modifyUser": "/api/3/appliances/57545210-2adc-472b-a24f-2df6ee8dfe63",
-          "modifyDate": 1657270455.821856,
+          "uuid": "e23ae855-530c-4b5d-95f2-9502177cf554",
+          "id": 2350,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Assets Properties",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Get a list of available asset property types that can be used with assets update operation",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672636906,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/2a51715c-0ad2-468d-aafe-a2c4fa529734",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Assets Properties",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "e524c682-01c1-416b-94bb-40aa2f2e6f55",
+                "params": {
+                  "max_results": 100
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_assets_properties",
+                "operationTitle": "Get Assets Properties",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "0772a39d-018c-4234-a8db-861df9af80d4"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "b1403fa9-6997-4e29-be20-f4ff37d95b4d",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "2a51715c-0ad2-468d-aafe-a2c4fa529734"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Destination IP Addresses",
+              "targetStep": "/api/3/workflow_steps/0772a39d-018c-4234-a8db-861df9af80d4",
+              "sourceStep": "/api/3/workflow_steps/2a51715c-0ad2-468d-aafe-a2c4fa529734",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "6ccae084-3da8-49d6-bc35-d9edddcb90d0"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "e30ae994-5db8-416c-9005-9f30ea0322a9",
+          "id": 2344,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "qradar"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": "Get Reference Tables",
+          "aliasName": null,
+          "tag": "#qradar",
+          "description": "Get a list of Reference Tables",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [],
+          "synchronous": false,
+          "lastModifyDate": 1672638396,
+          "collection": "/api/3/workflow_collections/5b8e0160-0f3a-483a-bdcd-a5e5dd0284b1",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/496b62a3-6d9d-4a94-ad83-c4c0d5377abf",
+          "steps": [
+            {
+              "@type": "WorkflowStep",
+              "name": "Get Reference Tables",
+              "description": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "e524c682-01c1-416b-94bb-40aa2f2e6f55",
+                "params": {
+                  "max_results": 100,
+                  "filter_string": ""
+                },
+                "version": "1.6.0",
+                "connector": "qradar",
+                "operation": "get_reference_tables",
+                "operationTitle": "Get Reference Tables",
+                "step_variables": []
+              },
+              "status": null,
+              "top": "165",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
+              "uuid": "381b18a8-69e9-4f9e-af4d-5487307d1081"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Alerts",
+              "description": null,
+              "arguments": {
+                "route": "4252c65e-94d2-4bab-a2d8-6884669a6d1c",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records}}"
+                  }
+                },
+                "displayConditions": {
+                  "alerts": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": []
+                  }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "singleRecordExecution": false
+              },
+              "status": null,
+              "top": "30",
+              "left": "125",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+              "group": null,
+              "uuid": "496b62a3-6d9d-4a94-ad83-c4c0d5377abf"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Alerts -> Get Destination IP Addresses",
+              "targetStep": "/api/3/workflow_steps/381b18a8-69e9-4f9e-af4d-5487307d1081",
+              "sourceStep": "/api/3/workflow_steps/496b62a3-6d9d-4a94-ad83-c4c0d5377abf",
+              "label": null,
+              "isExecuted": false,
+              "uuid": "85384fdb-1ec6-4ec8-9500-4d1998c9fe1d"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "uuid": "ec6f80b8-bfd6-456e-b1a9-c24fb508187b",
+          "id": 2349,
           "owners": [],
           "isPrivate": false,
           "deletedAt": null,
@@ -2680,11 +3706,11 @@
     }
   ],
   "exported_tags": [
-    "dataingestion",
-    "ingest",
     "qradar",
-    "create",
+    "dataingestion",
+    "qradar app",
+    "ingest",
     "fetch",
-    "qradar app"
+    "create"
   ]
 }

--- a/qradar/release_notes.md
+++ b/qradar/release_notes.md
@@ -1,13 +1,13 @@
-#### What's new in 1.6.0
+#### What's Improved
 
-- New actions:
-    - Get assets properties: Get a list of available asset property types that can be used with assets update operation
-    - Get assets: Get a list of available assets
-    - Update asset: Update one or multiple attributes of a specific asset defined by Asset ID
-    - Get cases: Get a list of Qradar cases
-    - Create case: Create a new case on Qradar
-    - Get reference tables: Get a list of Reference Tables
-    - Get table elements: Get records details of a reference table defined by name
-    - Add table element: Add or update an element in a reference table
-    - Delete table element: Delete element from a reference table
-    - Delete reference table: Delete a Reference Table or Purge its content
+- Added the following new operations and playbooks:
+    - Get assets properties
+    - Get assets
+    - Update asset
+    - Get cases
+    - Create case
+    - Get reference tables
+    - Get table elements
+    - Add table element
+    - Delete table element
+    - Delete reference table

--- a/qradar/release_notes.md
+++ b/qradar/release_notes.md
@@ -1,4 +1,13 @@
-#### What's Fixed
-  
-- Updated jinja .timestamp to .int_timestamp in the data ingestion playbooks.
-- Added the "PATCH" option to the "Request Method" parameter of the "Invoke QRadar REST API" operation.
+#### What's new in 1.6.0
+
+- New actions:
+    - Get assets properties: Get a list of available asset property types that can be used with assets update operation
+    - Get assets: Get a list of available assets
+    - Update asset: Update one or multiple attributes of a specific asset defined by Asset ID
+    - Get cases: Get a list of Qradar cases
+    - Create case: Create a new case on Qradar
+    - Get reference tables: Get a list of Reference Tables
+    - Get table elements: Get records details of a reference table defined by name
+    - Add table element: Add or update an element in a reference table
+    - Delete table element: Delete element from a reference table
+    - Delete reference table: Delete a Reference Table or Purge its content


### PR DESCRIPTION
Description:

Fixed bug in data ingestion playbook of Qradar

Mantis Link: https://mantis.fortinet.com/bug_view_page.php?bug_id=0871550

- New actions:
    - Get assets properties: Get a list of available asset property types that can be used with assets update operation
    - Get assets: Get a list of available assets
    - Update asset: Update one or multiple attributes of a specific asset defined by Asset ID
    - Get cases: Get a list of Qradar cases
    - Create case: Create a new case on Qradar
    - Get reference tables: Get a list of Reference Tables
    - Get table elements: Get records details of a reference table defined by name
    - Add table element: Add or update an element in a reference table
    - Delete table element: Delete element from a reference table
    - Delete reference table: Delete a Reference Table or Purge its content

Verified all 28 actions.

