### PR TITLE
Mitreusecases

### DIFF
--- a/.fortisoar/local_data.json
+++ b/.fortisoar/local_data.json
@@ -1,0 +1,22 @@
+{
+  "PYTHON_PATH": "C:\\Users\\Vishal\\AppData\\Local\\Programs\\Python\\Python312\\python.exe",
+  "qradar": {
+    "config": {
+      "test": {
+        "address": "192.168.60.35",
+        "verify_ssl": false,
+        "api_version": "14.0",
+        "token": "kl+leypBlXlt0FFOAuYn4mmhHEunbtJje6wh2MeC7Ujflffy43cXssrdEdwDZjqY",
+        "config_id": "2260ccad-8119-4bf3-8504-8f878caa9c4c"
+      }
+    },
+    "params": {
+      "get_mitre_mapping_related_to_an_offense": {
+        "offense_id": "106"
+      }
+    },
+    "output_schema": {
+      "get_mitre_mapping_related_to_an_offense": {}
+    }
+  }
+}

--- a/qradar/conn.py
+++ b/qradar/conn.py
@@ -89,7 +89,11 @@ class QradarConnection(object):
         return self.__parseRequestResult(res)
 
     def __getUrl(self, endpoint, params={}, headers={}):
-        url = '{}/{}'.format(self.base_url, endpoint)
+        if endpoint.startswith('console'):
+            url = '{}/{}'.format(self.address, endpoint)
+        else:
+            url = '{}/{}'.format(self.base_url, endpoint)
+
         self.log.debug('GET to URL: {}'.format(url))
         res = self.session.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT)
         logger.debug('\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>:\n{0}\n'.format(dump.dump_all(res).decode('utf-8')))
@@ -369,3 +373,8 @@ class QradarConnection(object):
         url_params, headers, data = self.__args_parser(params)
         self.log.debug('Deleting Record. \nParams: {0} \nHeaders: {1}'.format(url_params, headers))
         return self.__deleteUrl(endpoint, headers=headers, params=url_params)
+
+    def get_mitre_mapping_for_offense(self, params, rule_uuid):
+        mitre_endpoint = '/console/plugins/app_proxy:UseCaseManager_Service/api/mappings/by_name?rule_id=' + rule_uuid
+        rule_res = self.invokeQRadarAPI(endpoint=mitre_endpoint, method='GET', params=params, headers={})
+        return rule_res

--- a/qradar/docs/cyops-connector-qradar-v1.6.3.html
+++ b/qradar/docs/cyops-connector-qradar-v1.6.3.html
@@ -1,0 +1,803 @@
+<h2>About the connector</h2>
+
+<p>IBM QRadar is an enterprise security information and event management (SIEM) product. Fortinet FortiSOAR connector for IBM QRadar allows users to invoke QRadar API, perform Ariel Queries and operations like Get Offense,related events,update and close offenses.</p>
+
+<p>This document provides information about the IBM QRadar Connector, which facilitates automated interactions, with a IBM QRadar server using FortiSOAR&trade; playbooks. Add the IBM QRadar Connector as a step in FortiSOAR&trade; playbooks and perform automated operations with IBM QRadar.</p>
+
+<h3>Version information</h3>
+
+<p>Connector Version: 1.6.3</p>
+
+<p>FortiSOAR&trade; Version Tested on: 6.4.4-3164 and later</p>
+
+<p>IBM QRadar Version Tested on: </p>
+
+<p>Authored By: Fortinet</p>
+
+<p>Certified: Yes</p>
+
+<h2>Release Notes for version 1.6.3</h2>
+
+<p>Following enhancements have been made to the IBM QRadar Connector in version 1.6.3:</p>
+
+<ul>
+<li>Added a new action <code>Fetch Offenses from QRadar</code>.</li>
+</ul>
+
+<h2>Installing the connector</h2>
+
+<p>From FortiSOAR&trade; 5.0.0 onwards, use the <strong>Connector Store</strong> to install the connector. For the detailed procedure to install a connector, click <a href="https://docs.fortinet.com/document/fortisoar/0.0.0/installing-a-connector/1/installing-a-connector" target="_top">here</a>.<br>You can also use the following <code>yum</code> command as a root user to install connectors from an SSH session:</p>
+
+<p><code>yum install cyops-connector-qradar</code></p>
+
+<h2>Prerequisites to configuring the connector</h2>
+
+<ul>
+<li>You must have the URL of IBM QRadar server to which you will connect and perform automated operations and credentials to access that server.</li>
+<li>The FortiSOAR&trade; server should have outbound connectivity to port 443 on the IBM QRadar server.</li>
+</ul>
+
+<h2>Minimum Permissions Required</h2>
+
+<ul>
+<li>N/A</li>
+</ul>
+
+<h2>Configuring the connector</h2>
+
+<p>For the procedure to configure a connector, click <a href="https://docs.fortinet.com/document/fortisoar/0.0.0/configuring-a-connector/1/configuring-a-connector">here</a></p>
+
+<h3>Configuration parameters</h3>
+
+<p>In FortiSOAR&trade;, on the Connectors page, click the <strong>IBM QRadar</strong> connector row (if you are in the <strong>Grid</strong> view on the Connectors page) and in the <strong>Configurations&nbsp;</strong> tab enter the required configuration details:&nbsp;</p>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Address<br></td><td>Specify the IP address of the QRadar server from where the connector gets offenses information and to which you connect and perform automated operations.<br>
+<tr><td>API Token<br></td><td>Specify the API token to access the QRadar server to which you connect and perform automated operations.<br>
+<tr><td>API Version<br></td><td>Specify the version of the QRadar API to be used for performing automated operations. By default, this is set to 14.0.<br>
+<tr><td>Verify SSL<br></td><td>Specifies whether the SSL certificate for the server is to be verified or not. <br/>By default, this option is set as True.<br></td></tr>
+</tbody></table>
+
+<h2>Actions supported by the connector</h2>
+
+<p>The following automated operations can be included in playbooks and you can also use the annotations to access operations from FortiSOAR&trade; release 4.10.0 and onwards:</p>
+
+<table border=1><thead><tr><th>Function<br></th><th>Description<br></th><th>Annotation and Category<br></th></tr></thead><tbody><tr><td>Get Offenses from QRadar<br></td><td>Retrieves a list of offenses from the QRadar server based on the filter string that you have specified.<br></td><td>get_offenses <br/>Investigation<br></td></tr>
+<tr><td>Make an Ariel Query to QRadar<br></td><td>Executes an Ariel query on the QRadar server. QRadar uses the Ariel Query Language (AQL) to search for offenses or events based on query parameters.<br></td><td>run_query <br/>Investigation<br></td></tr>
+<tr><td>Get Offense Closing Reasons<br></td><td>Retrieves a list of closing reasons associated with all offenses from the QRadar server.<br></td><td>get_offense_closing_reasons <br/>Remediation<br></td></tr>
+<tr><td>Get Offense Types<br></td><td>Retrieves a list containing IDs of all the offense types from the QRadar server.<br></td><td>get_offense_type <br/>Investigation<br></td></tr>
+<tr><td>Get Offense Notes<br></td><td>Retrieves a list of notes associated with a specified offense in QRadar based on the offense ID you have specified.<br></td><td>get_notes <br/>Remediation<br></td></tr>
+<tr><td>Close Offense<br></td><td>Closes an offense on the QRadar server based on the offense ID that you have specified.<br></td><td>close_offense <br/>Remediation<br></td></tr>
+<tr><td>Create Note<br></td><td>Creates a note for a specified offense in QRadar based on the offense ID you have specified.<br></td><td>add_notes <br/>Remediation<br></td></tr>
+<tr><td>Get Events Related to an Offense<br></td><td>Retrieves details of events associated with a QRadar offense, from the QRadar server, based on the QRadar offense ID that you have specified.<br></td><td>get_events <br/>Investigation<br></td></tr>
+<tr><td>Get Source IP Addresses<br></td><td>Retrieves IP address details associated with source address IDs from the QRadar server, based on the source address IDs that you have specified<br></td><td>ip_details <br/>Investigation<br></td></tr>
+<tr><td>Get Destination IP Addresses<br></td><td>Retrieves IP address details associated with the destination address IDs from the QRadar server, based on the destination address IDs that you have specified<br></td><td>ip_details <br/>Investigation<br></td></tr>
+<tr><td>Invoke QRadar REST API<br></td><td>Invokes a function to Get or Post an API endpoint on the QRadar server.<br></td><td>api_call <br/>Investigation<br></td></tr>
+<tr><td>Manipulate Reference Set Content<br></td><td>Adds or deletes the content that you have specified from a reference set on QRadar.<br></td><td>handle_reference_set_value <br/>Investigation<br></td></tr>
+<tr><td>Get Assets Properties<br></td><td>Retrieves a detailed list of available asset properties or specific available asset properties from QRadar based on input parameters specified.<br></td><td>get_assets_properties <br/>Investigation<br></td></tr>
+<tr><td>Get Assets<br></td><td>Retrieves a detailed list of all available assets or specific available assets from QRadar based on input parameters specified.<br></td><td>get_assets <br/>Investigation<br></td></tr>
+<tr><td>Update Asset<br></td><td>Updates the attributes of a specific asset on the QRadar server based on the asset ID and asset properties you have specified. Note: You can retrieve the list of asset properties using the 'Get Assets Properties' operation.<br></td><td>update_asset <br/>Investigation<br></td></tr>
+<tr><td>Get Cases<br></td><td>Retrieves a detailed list of all cases or specific cases from QRadar based on input parameters specified. Note: This action is supported on QRadar API version 7.0 and later.<br></td><td>get_cases <br/>Investigation<br></td></tr>
+<tr><td>Create Case<br></td><td>Creates a new case on QRadar based on the case properties you have specified. Note: This action is supported on QRadar API version 7.0 and later.<br></td><td>create_case <br/>Investigation<br></td></tr>
+<tr><td>Get Reference Tables<br></td><td>Retrieves a detailed list of all reference tables or specific reference tables from QRadar based on input parameters specified.<br></td><td>get_reference_tables <br/>Investigation<br></td></tr>
+<tr><td>Delete or Purge Reference Table<br></td><td>Deletes a specific reference table and optionally purges its content from QRadar based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the 'Get Reference Tables' operation.<br></td><td>delete_reference_table <br/>Investigation<br></td></tr>
+<tr><td>Get Table Elements<br></td><td>Retrieves the record details (elements) of a specific reference table based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the 'Get Reference Tables' operation.<br></td><td>get_table_elements <br/>Investigation<br></td></tr>
+<tr><td>Add or Update Table Element<br></td><td>Adds or updates an element in the specified reference table based on the reference table name, outer key, inner key, and other input parameters you have specified.<br></td><td>add_table_element <br/>Investigation<br></td></tr>
+<tr><td>Delete Table Element<br></td><td>Specify the element to be deleted from a reference table on Qradar based on the input parameters specified.<br></td><td>delete_table_element <br/>Investigation<br></td></tr>
+<tr><td>Fetch Offenses from QRadar<br></td><td>Retrieves a list of offenses from the QRadar server based on the filter string and start datetime that you have specified.<br></td><td>fetch_offenses <br/>Investigation<br></td></tr>
+<tr><td>Get Mitre Mapping Related To Offense<br></td><td>Retrieves the MITRE mapping details associated with a QRadar offense from the QRadar server, based on the specified Offense ID.<br></td><td>get_mitre_mapping_related_to_an_offense <br/>Investigation<br></td></tr>
+</tbody></table>
+
+<h3>operation: Get Offenses from QRadar</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Filter String<br></td><td>Specify the filter string based on which you want to retrieve the list of offenses from QRadar. For example, assigned_to="admin".<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:</p>
+
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "credibility": "",
+
+<p></code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_address_ids": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "remote_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_address_ids": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "assigned_to": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "start_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "destination_networks": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "inactive": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "protected": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "policy_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "description": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "domain_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "relevance": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "device_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "security_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "flow_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "event_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_source": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "status": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "severity": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "username_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_user": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "follow_up": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_reason_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "close_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "last_updated_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "categories": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_type": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Make an Ariel Query to QRadar</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Ariel Search String<br></td><td>Specify the Ariel query that you want to run on the QRadar server.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains a non-dictionary value.</p>
+
+<h3>operation: Get Offense Closing Reasons</h3>
+
+<h4>Input parameters</h4>
+
+<p>None.</p>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "is_deleted": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "is_reserved": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "text": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Get Offense Types</h3>
+
+<h4>Input parameters</h4>
+
+<p>None.</p>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "property_name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "database_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "custom": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Get Offense Notes</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Offense ID<br></td><td>Specify the ID of the offense whose associated notes you want to retrieve from the QRadar server.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "note_text": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "create_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "username": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Close Offense</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Offense ID<br></td><td>Specify the ID of the offense that you want to close on the QRadar server.<br>
+</td></tr><tr><td>Offense Closing Reason - ID<br></td><td>Specify the ID of the offense closing reason using which you want to close the offense on the QRadar server.<br>
+</td></tr><tr><td>Closure Note<br></td><td>(Optional) Note that you want to associate with the offense that you want to close on the QRadar server.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "credibility": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_address_ids": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "remote_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_address_ids": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "assigned_to": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "start_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "destination_networks": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "inactive": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "protected": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "policy_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "description": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "domain_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "relevance": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "device_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "security_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "flow_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "event_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_source": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "status": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "severity": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "username_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_user": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "follow_up": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_reason_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "close_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "last_updated_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "categories": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_type": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Create Note</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Offense ID<br></td><td>Specify the ID of the offense for which you want to create a note on the QRadar server.<br>
+</td></tr><tr><td>Closure Note<br></td><td>Specify the text of the closure note that you want to create for the specified offense on the QRadar server.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "note_text": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "create_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "username": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Get Events Related to an Offense</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>QRadar Offense ID<br></td><td>Specify the Offense ID based on which you want to retrieve events from QRadar.<br>
+</td></tr><tr><td>Offense Start Time<br></td><td>Specify the number of milliseconds since the epoch from the offense was started.<br>
+</td></tr><tr><td>Offense Last Update Time<br></td><td>Specify the number of milliseconds since the epoch from the offense was last modified.<br>
+</td></tr><tr><td>Max Events to return<br></td><td>(Optional) Specify the maximum number of events that this operation should return.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "events": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "qid": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "category": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "sourceip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "username": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "starttime": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "eventcount": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "identityip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "protocolid": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "sourceport": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "logsourceid": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "destinationip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "destinationport": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ]
+</code><code><br>}</code></p>
+
+<h3>operation: Get Source IP Addresses</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Source Address Ids<br></td><td>Specify the IDs of source addresses based on which you want to retrieve IP address details from the QRadar server. For example, [3,4,5].<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_ip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "magnitude": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Get Destination IP Addresses</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Destination Address Ids<br></td><td>IDs of destination addresses based on which you want to retrieve IP address details from the QRadar server. For example, [3,4,5].<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_ip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "magnitude": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Invoke QRadar REST API</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Endpoint<br></td><td>Specifies the REST endpoint. For example, /siem/offenses.<br>
+</td></tr><tr><td>Request Method<br></td><td>Select the request method. You can choose between GET, POST, or PATCH. If you select GET, then you should specify the Request Parameters parameter. In the Request parameters parameter, specify the request parameters for the specified endpoint. If you select POST, then you can specify either the Request Parameters in JSON Format or the Request Payload in JSON Format parameter. In these parameters, specify either the request parameters or the request JSON payload for the specified endpoint. If you select PATCH, then you can specify either the Request Parameters in JSON Format or the Request Payload in JSON Format parameter. In these parameters, specify either the request parameters or the request JSON payload for the specified endpoint.<br>
+<strong>If you choose 'GET'</strong><ul><li>Request Parameters: Provide the request parameters for the above endpoint that you have specified</li></ul><strong>If you choose 'POST'</strong><ul><li>Provide Parameters: </li><strong>If you choose 'Request Parameters'</strong><ul><li>Request Parameters in JSON Format: Provide the request parameters for the above endpoint that you have specified</li></ul><strong>If you choose 'Request Payload'</strong><ul><li>Request Payload in JSON Format: Provide the request json payload for the above endpoint that you have specified</li></ul></ul><strong>If you choose 'PATCH'</strong><ul><li>Provide Parameters: </li><strong>If you choose 'Request Parameters'</strong><ul><li>Request Parameters in JSON Format: Provide the request parameters for the above endpoint that you have specified</li></ul><strong>If you choose 'Request Payload'</strong><ul><li>Request Payload in JSON Format: Provide the request json payload for the above endpoint that you have specified</li></ul></ul></td></tr><tr><td>Headers in json format<br></td><td>(Optional) Additional JSON formatted headers. The following headers are already added by the connector: 'Accept': 'application/JSON', 'Content-Type': 'application/JSON', 'SEC': <token>, 'Version': <api_version>,<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains a non-dictionary value.</p>
+
+<h3>operation: Manipulate Reference Set Content</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Request Method<br></td><td>Select the request method option of the operation that you want to perform on the specified reference set in QRadar. You can choose from following options: Retrieves Value: Specify values in the following field: Reference Set Name: Specify the name of the reference set from which to retrieve the content in QRadar. Add Value: Specify values in the following field: Reference Set Name: Specify the name of the reference set in which to add the content in QRadar. Value: Specify the value to add to the specified reference set. Delete Value: Specify values in the following field: Reference Set Name: Specify the name of the reference set from which to delete the content in QRadar. Value: Specify the value to delete from the specified reference set.<br>
+<strong>If you choose 'Retrieves Value'</strong><ul><li>Reference Set Name: Specify the name of the reference set to be used for this operation based on the option you have specified in the Request Method. If you choose Add Value as the Request Method, then this operation will add the specified value to the reference set you have specified in this field. If you choose Delete Value as the Request Method, then this operation will delete the specified value from the reference set you have specified in this field. If you choose Retrieves Value as the Request Method, then this operation will retrieve the values of the reference set you have specified in this field.</li></ul><strong>If you choose 'Add Value'</strong><ul><li>Reference Set Name: Specify the name of the reference set to be used for this operation based on the option you have specified in the Request Method. If you choose Add Value as the Request Method, then this operation will add the specified value to the reference set you have specified in this field. If you choose Delete Value as the Request Method, then this operation will delete the specified value from the reference set you have specified in this field. If you choose Retrieves Value as the Request Method, then this operation will retrieve the values of the reference set you have specified in this field.</li><li>Value: Specify the value that you want to add or remove from the specified reference set. You must specify the value in this field if you have chosen Add Value or Delete Value as the Request Method.</li></ul><strong>If you choose 'Delete Value'</strong><ul><li>Reference Set Name: Specify the name of the reference set to be used for this operation based on the option you have specified in the Request Method. If you choose Add Value as the Request Method, then this operation will add the specified value to the reference set you have specified in this field. If you choose Delete Value as the Request Method, then this operation will delete the specified value from the reference set you have specified in this field. If you choose Retrieves Value as the Request Method, then this operation will retrieve the values of the reference set you have specified in this field.</li><li>Value: Specify the value that you want to add or remove from the specified reference set. You must specify the value in this field if you have chosen Add Value or Delete Value as the Request Method.</li></ul></td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:</p>
+
+<p>Output schema when you choose "Request Method" as "Retrieves Value":
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "data": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "first_seen": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "last_seen": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "source": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "value": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "message": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": ""
+</code><code><br>}</code></p>
+
+<p>If you choose "Add Value" or "Delete Value" as the "Request Method", then the output contains the following populated JSON schema:
+ <code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "message": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Get Assets Properties</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Limit<br></td><td>Specify the maximum count of asset properties to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.<br>
+</td></tr><tr><td>Filter<br></td><td>Specify the parameters to be used to filter (restrict) the list of asset properties to be returned by this operation in the response.<br>
+</td></tr><tr><td>Fields<br></td><td>Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "data_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "display": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "custom": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "state": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Get Assets</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Filter<br></td><td>Specify the parameters to be used to filter (restrict) the list of assets to be returned by this operation in the response.<br>
+</td></tr><tr><td>Limit<br></td><td>Specify the maximum count of assets to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.<br>
+</td></tr><tr><td>Fields<br></td><td>Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Sort<br></td><td>Specify the fields using which you want to sort the response. Specify the negative (-) sign to sort the results in descending order and the positive sign (+) to sort in ascending order.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "vulnerability_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "interfaces": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "mac_address": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "last_seen_profiler": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "created": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "last_seen_scanner": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "first_seen_scanner": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "ip_addresses": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "last_seen_profiler": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "created": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "last_seen_scanner": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "first_seen_scanner": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "network_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "first_seen_profiler": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "value": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "first_seen_profiler": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "risk_score_sum": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "hostnames": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "users": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "domain_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "properties": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "last_reported": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "type_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "last_reported_by": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "value": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "products": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Update Asset</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Asset ID<br></td><td>Specify the ID of the asset whose properties you want to update on QRadar.<br>
+</td></tr><tr><td>Asset Properties<br></td><td>Specify a JSON dictionary with the asset properties that you want to update in the specified asset you want to update on QRadar<br>
+</td></tr><tr><td>Content Type<br></td><td>This is a system field that cannot be edited.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:</p>
+
+<p>The output contains a non-dictionary value.</p>
+
+<h3>operation: Get Cases</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Fields<br></td><td>Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Filter<br></td><td>Specify the parameters to be used to filter (restrict) the list of cases to be returned by this operation in the response.<br>
+</td></tr><tr><td>Limit<br></td><td>Specify the maximum count of cases to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "assigned_to": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Create Case</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Case Properties<br></td><td>Specify a JSON dictionary with the case properties using which you want to create the case on QRadar.<br>
+</td></tr><tr><td>Content Type<br></td><td>This is a system field that cannot be edited.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "case_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "state": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "assigned_to": []
+</code><code><br>}</code></p>
+
+<h3>operation: Get Reference Tables</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Filter<br></td><td>Specify the parameters to be used to filter (restrict) the list of reference tables to be returned by this operation in the response.<br>
+</td></tr><tr><td>Limit<br></td><td>Specify the maximum count of reference tables to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.<br>
+</td></tr><tr><td>Fields<br></td><td>Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "key_name_types": {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        "port": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        "source_ip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        "timestamp": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    },
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Delete or Purge Reference Table</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Reference Table Name<br></td><td>Specify the name of the reference table that you want to delete from QRadar.<br>
+</td></tr><tr><td>Purge Table<br></td><td>Select the 'true' option from the Purge Table drop-down list if you want to have the contents of the specified reference table to be purged from QRadar, i.e., in this case, the structure of the specified reference table is retained. Select the 'false' (default) option from the Purge Table drop-down list to purge the contents of the specified reference table, i.e., in this case, the specified reference table is completely removed.<br>
+</td></tr><tr><td>Fields<br></td><td>(Optional) Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Namespace<br></td><td>(Optional) Specify the namespace of the reference table that you want to delete from QRadar. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "created_by": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "created": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "modified": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "started": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "completed": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "message": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "status": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Get Table Elements</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Reference Table Name<br></td><td>Specify the name of the reference table whose record details (elements) you want to retrieve from QRadar.<br>
+</td></tr><tr><td>Limit<br></td><td>(Optional) Specify the maximum count of table elements to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.<br>
+</td></tr><tr><td>Fields<br></td><td>(Optional) Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Namespace<br></td><td>(Optional) Specify the namespace of the reference table whose record details (elements) you want to retrieve from QRadar. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "data": {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        "outer_key": {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "inner_key": {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                "last_seen": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                "first_seen": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                "source": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                "value": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    },
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "key_name_types": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Add or Update Table Element</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Reference Table Name<br></td><td>Specify the name of the reference table in which you want to add or update the specified element.<br>
+</td></tr><tr><td>Outer Key<br></td><td>Specify the outer key in which you want to add or update the specified element.<br>
+</td></tr><tr><td>Inner Key<br></td><td>Specify the inner key in which you want to add or update the specified element.<br>
+</td></tr><tr><td>Value<br></td><td>Specify the value of the element that you want to add or update in the specified reference table. Note: Date values must be represented in Unix Epoch milliseconds.<br>
+</td></tr><tr><td>Domain ID<br></td><td>(Optional) In the case of MSSP setups, you can specify the domain ID to be set for the 'value' you have specified in the 'Value' field. If the 'Domain ID' field is null, then the shared domain is used.<br>
+</td></tr><tr><td>Element Source<br></td><td>(Optional) Specify the source of the specified element that you want to add or update in the specified table. By default, this is set to 'FortiSOAR'.<br>
+</td></tr><tr><td>Fields<br></td><td>(Optional) Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Namespace<br></td><td>(Optional) Specify the namespace of the reference table in which you want to add or update the specified element. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "key_name_types": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Delete Table Element</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Reference Table Name<br></td><td>Specify the name of the reference table from which you want to delete the specified element.<br>
+</td></tr><tr><td>Outer Key<br></td><td>Specify the outer key from which you want to delete the specified element.<br>
+</td></tr><tr><td>Inner Key<br></td><td>Specify the inner key from which you want to delete the specified element.<br>
+</td></tr><tr><td>value<br></td><td>Specify the value of the element that you want to delete from the specified reference table. Note: Date values must be represented in Epoch milliseconds.<br>
+</td></tr><tr><td>Domain ID<br></td><td>(Optional) In the case of MSSP setups, you can specify the domain ID to be set for the 'value' you have specified in the 'Value' field. If the 'Domain ID' field is null, then the shared domain is used.<br>
+</td></tr><tr><td>Fields<br></td><td>(Optional) Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Namespace<br></td><td>(Optional) Specify the namespace of the reference table from which you want to delete the specified element. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "key_name_types": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": ""
+</code><code><br>}</code></p>
+
+<h3>operation: Fetch Offenses from QRadar</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Filter String<br></td><td>Specify the filter string based on which to retrieve the list of offenses from QRadar. For example, assigned_to="admin".<br>
+</td></tr><tr><td>Created After<br></td><td>Select the date and time using which to filter the result set to only include items that have been created after the specified timestamp.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "rules": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "type": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "status": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "inactive": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "severity": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "domain_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "follow_up": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "protected": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "relevance": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "categories": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "close_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "flow_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "start_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "assigned_to": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "credibility": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "description": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "event_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "log_sources": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "type_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "type_name": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_user": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "device_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_source": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "username_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_reason_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "last_updated_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_address_ids": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "last_persisted_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "destination_networks": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "first_persisted_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "policy_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_address_details": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "source_ip": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "security_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "remote_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "destination_address_details": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "local_destination_ip": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_address_ids": []
+</code><code><br>}</code></p>
+
+<h3>operation: Get Mitre Mapping Related To Offense</h3>
+
+<h4>Input parameters</h4>
+
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>QRadar Offense ID<br></td><td>Specify the Offense ID based on which you want to retrieve mitre mapping from QRadar.<br>
+</td></tr></tbody></table>
+
+<h4>Output</h4>
+
+<p>The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "rule_name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "override_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "has_ibm_default": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "last_updated": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "min_mitre_version": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "mapping": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "tactic_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "tactic_name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "confidence": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "user_override": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "enabled": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "ibm_default": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "techniques": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "technique_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "technique_name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "confidence": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "enabled": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            ]
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ]
+</code><code><br>}</code></p>
+
+<h2>Included playbooks</h2>
+
+<p>The <code>Sample - qradar - 1.6.3</code> playbook collection comes bundled with the IBM QRadar connector. These playbooks contain steps using which you can perform all supported actions. You can see bundled playbooks in the <strong>Automation</strong> &gt; <strong>Playbooks</strong> section in FortiSOAR<sup>TM</sup> after importing the IBM QRadar connector.</p>
+
+<ul>
+<li>Add or Update Table Element</li>
+<li>Close Offense</li>
+<li>Create Case</li>
+<li>Create Note</li>
+<li>Delete Table Element</li>
+<li>Delete or Purge Reference Table</li>
+<li>Fetch Offenses from QRadar</li>
+<li>Get Assets</li>
+<li>Get Assets Properties</li>
+<li>Get Cases</li>
+<li>Get Destination IP Addresses</li>
+<li>Get Events Related to an Offense</li>
+<li>Get Mitre Mapping Related To Offense</li>
+<li>Get Offense Closing Reasons</li>
+<li>Get Offense Notes</li>
+<li>Get Offense Types</li>
+<li>Get Offenses from QRadar</li>
+<li>Get Reference Tables</li>
+<li>Get Source IP Addresses</li>
+<li>Get Table Elements</li>
+<li>Invoke QRadar REST API</li>
+<li>Make an Ariel Query to QRadar</li>
+<li>Manipulate Reference Set Content</li>
+<li>Update Asset</li>
+</ul>
+
+<p><strong>Note</strong>: If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.</p>
+
+<h2>Data Ingestion Support</h2>
+
+<p>Use the Data Ingestion Wizard to easily ingest data into FortiSOAR&trade; by pulling events/alerts/incidents, based on the requirement.</p>
+
+<p><strong>TODO:</strong> provide the list of steps to configure the ingestion with the screen shots and limitations if any in this section.</p>

--- a/qradar/docs/cyops-connector-qradar-v1.6.3.md
+++ b/qradar/docs/cyops-connector-qradar-v1.6.3.md
@@ -1,0 +1,706 @@
+## About the connector
+IBM QRadar is an enterprise security information and event management (SIEM) product. Fortinet FortiSOAR connector for IBM QRadar allows users to invoke QRadar API, perform Ariel Queries and operations like Get Offense,related events,update and close offenses.
+<p>This document provides information about the IBM QRadar Connector, which facilitates automated interactions, with a IBM QRadar server using FortiSOAR&trade; playbooks. Add the IBM QRadar Connector as a step in FortiSOAR&trade; playbooks and perform automated operations with IBM QRadar.</p>
+
+### Version information
+
+Connector Version: 1.6.3
+
+FortiSOAR&trade; Version Tested on: 6.4.4-3164 and later
+
+IBM QRadar Version Tested on: 
+
+Authored By: Fortinet
+
+Certified: Yes
+## Release Notes for version 1.6.3
+Following enhancements have been made to the IBM QRadar Connector in version 1.6.3:
+<ul>
+<li>Added a new action <code>Fetch Offenses from QRadar</code>.</li>
+</ul>
+## Installing the connector
+<p>From FortiSOAR&trade; 5.0.0 onwards, use the <strong>Connector Store</strong> to install the connector. For the detailed procedure to install a connector, click <a href="https://docs.fortinet.com/document/fortisoar/0.0.0/installing-a-connector/1/installing-a-connector" target="_top">here</a>.<br>You can also use the following <code>yum</code> command as a root user to install connectors from an SSH session:</p>
+`yum install cyops-connector-qradar`
+
+## Prerequisites to configuring the connector
+- You must have the URL of IBM QRadar server to which you will connect and perform automated operations and credentials to access that server.
+- The FortiSOAR&trade; server should have outbound connectivity to port 443 on the IBM QRadar server.
+
+## Minimum Permissions Required
+- N/A
+
+## Configuring the connector
+For the procedure to configure a connector, click [here](https://docs.fortinet.com/document/fortisoar/0.0.0/configuring-a-connector/1/configuring-a-connector)
+### Configuration parameters
+<p>In FortiSOAR&trade;, on the Connectors page, click the <strong>IBM QRadar</strong> connector row (if you are in the <strong>Grid</strong> view on the Connectors page) and in the <strong>Configurations&nbsp;</strong> tab enter the required configuration details:&nbsp;</p>
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Address<br></td><td>Specify the IP address of the QRadar server from where the connector gets offenses information and to which you connect and perform automated operations.<br>
+<tr><td>API Token<br></td><td>Specify the API token to access the QRadar server to which you connect and perform automated operations.<br>
+<tr><td>API Version<br></td><td>Specify the version of the QRadar API to be used for performing automated operations. By default, this is set to 14.0.<br>
+<tr><td>Verify SSL<br></td><td>Specifies whether the SSL certificate for the server is to be verified or not. <br/>By default, this option is set as True.<br></td></tr>
+</tbody></table>
+
+## Actions supported by the connector
+The following automated operations can be included in playbooks and you can also use the annotations to access operations from FortiSOAR&trade; release 4.10.0 and onwards:
+<table border=1><thead><tr><th>Function<br></th><th>Description<br></th><th>Annotation and Category<br></th></tr></thead><tbody><tr><td>Get Offenses from QRadar<br></td><td>Retrieves a list of offenses from the QRadar server based on the filter string that you have specified.<br></td><td>get_offenses <br/>Investigation<br></td></tr>
+<tr><td>Make an Ariel Query to QRadar<br></td><td>Executes an Ariel query on the QRadar server. QRadar uses the Ariel Query Language (AQL) to search for offenses or events based on query parameters.<br></td><td>run_query <br/>Investigation<br></td></tr>
+<tr><td>Get Offense Closing Reasons<br></td><td>Retrieves a list of closing reasons associated with all offenses from the QRadar server.<br></td><td>get_offense_closing_reasons <br/>Remediation<br></td></tr>
+<tr><td>Get Offense Types<br></td><td>Retrieves a list containing IDs of all the offense types from the QRadar server.<br></td><td>get_offense_type <br/>Investigation<br></td></tr>
+<tr><td>Get Offense Notes<br></td><td>Retrieves a list of notes associated with a specified offense in QRadar based on the offense ID you have specified.<br></td><td>get_notes <br/>Remediation<br></td></tr>
+<tr><td>Close Offense<br></td><td>Closes an offense on the QRadar server based on the offense ID that you have specified.<br></td><td>close_offense <br/>Remediation<br></td></tr>
+<tr><td>Create Note<br></td><td>Creates a note for a specified offense in QRadar based on the offense ID you have specified.<br></td><td>add_notes <br/>Remediation<br></td></tr>
+<tr><td>Get Events Related to an Offense<br></td><td>Retrieves details of events associated with a QRadar offense, from the QRadar server, based on the QRadar offense ID that you have specified.<br></td><td>get_events <br/>Investigation<br></td></tr>
+<tr><td>Get Source IP Addresses<br></td><td>Retrieves IP address details associated with source address IDs from the QRadar server, based on the source address IDs that you have specified<br></td><td>ip_details <br/>Investigation<br></td></tr>
+<tr><td>Get Destination IP Addresses<br></td><td>Retrieves IP address details associated with the destination address IDs from the QRadar server, based on the destination address IDs that you have specified<br></td><td>ip_details <br/>Investigation<br></td></tr>
+<tr><td>Invoke QRadar REST API<br></td><td>Invokes a function to Get or Post an API endpoint on the QRadar server.<br></td><td>api_call <br/>Investigation<br></td></tr>
+<tr><td>Manipulate Reference Set Content<br></td><td>Adds or deletes the content that you have specified from a reference set on QRadar.<br></td><td>handle_reference_set_value <br/>Investigation<br></td></tr>
+<tr><td>Get Assets Properties<br></td><td>Retrieves a detailed list of available asset properties or specific available asset properties from QRadar based on input parameters specified.<br></td><td>get_assets_properties <br/>Investigation<br></td></tr>
+<tr><td>Get Assets<br></td><td>Retrieves a detailed list of all available assets or specific available assets from QRadar based on input parameters specified.<br></td><td>get_assets <br/>Investigation<br></td></tr>
+<tr><td>Update Asset<br></td><td>Updates the attributes of a specific asset on the QRadar server based on the asset ID and asset properties you have specified. Note: You can retrieve the list of asset properties using the 'Get Assets Properties' operation.<br></td><td>update_asset <br/>Investigation<br></td></tr>
+<tr><td>Get Cases<br></td><td>Retrieves a detailed list of all cases or specific cases from QRadar based on input parameters specified. Note: This action is supported on QRadar API version 7.0 and later.<br></td><td>get_cases <br/>Investigation<br></td></tr>
+<tr><td>Create Case<br></td><td>Creates a new case on QRadar based on the case properties you have specified. Note: This action is supported on QRadar API version 7.0 and later.<br></td><td>create_case <br/>Investigation<br></td></tr>
+<tr><td>Get Reference Tables<br></td><td>Retrieves a detailed list of all reference tables or specific reference tables from QRadar based on input parameters specified.<br></td><td>get_reference_tables <br/>Investigation<br></td></tr>
+<tr><td>Delete or Purge Reference Table<br></td><td>Deletes a specific reference table and optionally purges its content from QRadar based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the 'Get Reference Tables' operation.<br></td><td>delete_reference_table <br/>Investigation<br></td></tr>
+<tr><td>Get Table Elements<br></td><td>Retrieves the record details (elements) of a specific reference table based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the 'Get Reference Tables' operation.<br></td><td>get_table_elements <br/>Investigation<br></td></tr>
+<tr><td>Add or Update Table Element<br></td><td>Adds or updates an element in the specified reference table based on the reference table name, outer key, inner key, and other input parameters you have specified.<br></td><td>add_table_element <br/>Investigation<br></td></tr>
+<tr><td>Delete Table Element<br></td><td>Specify the element to be deleted from a reference table on Qradar based on the input parameters specified.<br></td><td>delete_table_element <br/>Investigation<br></td></tr>
+<tr><td>Fetch Offenses from QRadar<br></td><td>Retrieves a list of offenses from the QRadar server based on the filter string and start datetime that you have specified.<br></td><td>fetch_offenses <br/>Investigation<br></td></tr>
+<tr><td>Get Mitre Mapping Related To Offense<br></td><td>Retrieves the MITRE mapping details associated with a QRadar offense from the QRadar server, based on the specified Offense ID.<br></td><td>get_mitre_mapping_related_to_an_offense <br/>Investigation<br></td></tr>
+</tbody></table>
+
+### operation: Get Offenses from QRadar
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Filter String<br></td><td>Specify the filter string based on which you want to retrieve the list of offenses from QRadar. For example, assigned_to="admin".<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "credibility": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_address_ids": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "remote_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_address_ids": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "assigned_to": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "start_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "destination_networks": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "inactive": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "protected": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "policy_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "description": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "domain_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "relevance": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "device_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "security_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "flow_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "event_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_source": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "status": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "severity": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "username_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_user": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "follow_up": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_reason_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "close_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "last_updated_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "categories": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_type": ""
+</code><code><br>}</code>
+
+### operation: Make an Ariel Query to QRadar
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Ariel Search String<br></td><td>Specify the Ariel query that you want to run on the QRadar server.<br>
+</td></tr></tbody></table>
+
+#### Output
+
+ The output contains a non-dictionary value.
+
+### operation: Get Offense Closing Reasons
+#### Input parameters
+None.
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "is_deleted": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "is_reserved": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "text": ""
+</code><code><br>}</code>
+
+### operation: Get Offense Types
+#### Input parameters
+None.
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "property_name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "database_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "custom": ""
+</code><code><br>}</code>
+
+### operation: Get Offense Notes
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Offense ID<br></td><td>Specify the ID of the offense whose associated notes you want to retrieve from the QRadar server.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "note_text": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "create_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "username": ""
+</code><code><br>}</code>
+
+### operation: Close Offense
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Offense ID<br></td><td>Specify the ID of the offense that you want to close on the QRadar server.<br>
+</td></tr><tr><td>Offense Closing Reason - ID<br></td><td>Specify the ID of the offense closing reason using which you want to close the offense on the QRadar server.<br>
+</td></tr><tr><td>Closure Note<br></td><td>(Optional) Note that you want to associate with the offense that you want to close on the QRadar server.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "credibility": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_address_ids": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "remote_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_address_ids": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "assigned_to": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "start_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "destination_networks": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "inactive": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "protected": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "policy_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "description": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "domain_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "relevance": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "device_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "security_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "flow_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "event_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_source": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "status": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "severity": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "username_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_user": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "follow_up": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_reason_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "close_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "last_updated_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "categories": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_type": ""
+</code><code><br>}</code>
+
+### operation: Create Note
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Offense ID<br></td><td>Specify the ID of the offense for which you want to create a note on the QRadar server.<br>
+</td></tr><tr><td>Closure Note<br></td><td>Specify the text of the closure note that you want to create for the specified offense on the QRadar server.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "note_text": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "create_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "username": ""
+</code><code><br>}</code>
+
+### operation: Get Events Related to an Offense
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>QRadar Offense ID<br></td><td>Specify the Offense ID based on which you want to retrieve events from QRadar.<br>
+</td></tr><tr><td>Offense Start Time<br></td><td>Specify the number of milliseconds since the epoch from the offense was started.<br>
+</td></tr><tr><td>Offense Last Update Time<br></td><td>Specify the number of milliseconds since the epoch from the offense was last modified.<br>
+</td></tr><tr><td>Max Events to return<br></td><td>(Optional) Specify the maximum number of events that this operation should return.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "events": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "qid": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "category": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "sourceip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "username": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "starttime": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "eventcount": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "identityip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "protocolid": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "sourceport": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "logsourceid": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "destinationip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "destinationport": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ]
+</code><code><br>}</code>
+
+### operation: Get Source IP Addresses
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Source Address Ids<br></td><td>Specify the IDs of source addresses based on which you want to retrieve IP address details from the QRadar server. For example, [3,4,5].<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_ip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "magnitude": ""
+</code><code><br>}</code>
+
+### operation: Get Destination IP Addresses
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Destination Address Ids<br></td><td>IDs of destination addresses based on which you want to retrieve IP address details from the QRadar server. For example, [3,4,5].<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_ip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "magnitude": ""
+</code><code><br>}</code>
+
+### operation: Invoke QRadar REST API
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Endpoint<br></td><td>Specifies the REST endpoint. For example, /siem/offenses.<br>
+</td></tr><tr><td>Request Method<br></td><td>Select the request method. You can choose between GET, POST, or PATCH. If you select GET, then you should specify the Request Parameters parameter. In the Request parameters parameter, specify the request parameters for the specified endpoint. If you select POST, then you can specify either the Request Parameters in JSON Format or the Request Payload in JSON Format parameter. In these parameters, specify either the request parameters or the request JSON payload for the specified endpoint. If you select PATCH, then you can specify either the Request Parameters in JSON Format or the Request Payload in JSON Format parameter. In these parameters, specify either the request parameters or the request JSON payload for the specified endpoint.<br>
+<strong>If you choose 'GET'</strong><ul><li>Request Parameters: Provide the request parameters for the above endpoint that you have specified</li></ul><strong>If you choose 'POST'</strong><ul><li>Provide Parameters: </li><strong>If you choose 'Request Parameters'</strong><ul><li>Request Parameters in JSON Format: Provide the request parameters for the above endpoint that you have specified</li></ul><strong>If you choose 'Request Payload'</strong><ul><li>Request Payload in JSON Format: Provide the request json payload for the above endpoint that you have specified</li></ul></ul><strong>If you choose 'PATCH'</strong><ul><li>Provide Parameters: </li><strong>If you choose 'Request Parameters'</strong><ul><li>Request Parameters in JSON Format: Provide the request parameters for the above endpoint that you have specified</li></ul><strong>If you choose 'Request Payload'</strong><ul><li>Request Payload in JSON Format: Provide the request json payload for the above endpoint that you have specified</li></ul></ul></td></tr><tr><td>Headers in json format<br></td><td>(Optional) Additional JSON formatted headers. The following headers are already added by the connector: 'Accept': 'application/JSON', 'Content-Type': 'application/JSON', 'SEC': <token>, 'Version': <api_version>,<br>
+</td></tr></tbody></table>
+
+#### Output
+
+ The output contains a non-dictionary value.
+
+### operation: Manipulate Reference Set Content
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Request Method<br></td><td>Select the request method option of the operation that you want to perform on the specified reference set in QRadar. You can choose from following options: Retrieves Value: Specify values in the following field: Reference Set Name: Specify the name of the reference set from which to retrieve the content in QRadar. Add Value: Specify values in the following field: Reference Set Name: Specify the name of the reference set in which to add the content in QRadar. Value: Specify the value to add to the specified reference set. Delete Value: Specify values in the following field: Reference Set Name: Specify the name of the reference set from which to delete the content in QRadar. Value: Specify the value to delete from the specified reference set.<br>
+<strong>If you choose 'Retrieves Value'</strong><ul><li>Reference Set Name: Specify the name of the reference set to be used for this operation based on the option you have specified in the Request Method. If you choose Add Value as the Request Method, then this operation will add the specified value to the reference set you have specified in this field. If you choose Delete Value as the Request Method, then this operation will delete the specified value from the reference set you have specified in this field. If you choose Retrieves Value as the Request Method, then this operation will retrieve the values of the reference set you have specified in this field.</li></ul><strong>If you choose 'Add Value'</strong><ul><li>Reference Set Name: Specify the name of the reference set to be used for this operation based on the option you have specified in the Request Method. If you choose Add Value as the Request Method, then this operation will add the specified value to the reference set you have specified in this field. If you choose Delete Value as the Request Method, then this operation will delete the specified value from the reference set you have specified in this field. If you choose Retrieves Value as the Request Method, then this operation will retrieve the values of the reference set you have specified in this field.</li><li>Value: Specify the value that you want to add or remove from the specified reference set. You must specify the value in this field if you have chosen Add Value or Delete Value as the Request Method.</li></ul><strong>If you choose 'Delete Value'</strong><ul><li>Reference Set Name: Specify the name of the reference set to be used for this operation based on the option you have specified in the Request Method. If you choose Add Value as the Request Method, then this operation will add the specified value to the reference set you have specified in this field. If you choose Delete Value as the Request Method, then this operation will delete the specified value from the reference set you have specified in this field. If you choose Retrieves Value as the Request Method, then this operation will retrieve the values of the reference set you have specified in this field.</li><li>Value: Specify the value that you want to add or remove from the specified reference set. You must specify the value in this field if you have chosen Add Value or Delete Value as the Request Method.</li></ul></td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+
+Output schema when you choose "Request Method" as "Retrieves Value":
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "data": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "first_seen": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "last_seen": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "source": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "value": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "message": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": ""
+</code><code><br>}</code>
+
+If you choose "Add Value" or "Delete Value" as the "Request Method", then the output contains the following populated JSON schema:
+ <code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "message": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": ""
+</code><code><br>}</code>
+
+### operation: Get Assets Properties
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Limit<br></td><td>Specify the maximum count of asset properties to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.<br>
+</td></tr><tr><td>Filter<br></td><td>Specify the parameters to be used to filter (restrict) the list of asset properties to be returned by this operation in the response.<br>
+</td></tr><tr><td>Fields<br></td><td>Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "data_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "display": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "custom": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "state": ""
+</code><code><br>}</code>
+
+### operation: Get Assets
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Filter<br></td><td>Specify the parameters to be used to filter (restrict) the list of assets to be returned by this operation in the response.<br>
+</td></tr><tr><td>Limit<br></td><td>Specify the maximum count of assets to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.<br>
+</td></tr><tr><td>Fields<br></td><td>Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Sort<br></td><td>Specify the fields using which you want to sort the response. Specify the negative (-) sign to sort the results in descending order and the positive sign (+) to sort in ascending order.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "vulnerability_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "interfaces": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "mac_address": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "last_seen_profiler": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "created": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "last_seen_scanner": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "first_seen_scanner": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "ip_addresses": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "last_seen_profiler": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "created": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "last_seen_scanner": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "first_seen_scanner": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "network_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "first_seen_profiler": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "value": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "first_seen_profiler": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "risk_score_sum": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "hostnames": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "users": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "domain_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "properties": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "last_reported": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "type_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "last_reported_by": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "value": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "products": ""
+</code><code><br>}</code>
+
+### operation: Update Asset
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Asset ID<br></td><td>Specify the ID of the asset whose properties you want to update on QRadar.<br>
+</td></tr><tr><td>Asset Properties<br></td><td>Specify a JSON dictionary with the asset properties that you want to update in the specified asset you want to update on QRadar<br>
+</td></tr><tr><td>Content Type<br></td><td>This is a system field that cannot be edited.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+
+The output contains a non-dictionary value.
+
+### operation: Get Cases
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Fields<br></td><td>Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Filter<br></td><td>Specify the parameters to be used to filter (restrict) the list of cases to be returned by this operation in the response.<br>
+</td></tr><tr><td>Limit<br></td><td>Specify the maximum count of cases to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "assigned_to": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": ""
+</code><code><br>}</code>
+
+### operation: Create Case
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Case Properties<br></td><td>Specify a JSON dictionary with the case properties using which you want to create the case on QRadar.<br>
+</td></tr><tr><td>Content Type<br></td><td>This is a system field that cannot be edited.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "case_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "state": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "assigned_to": []
+</code><code><br>}</code>
+
+### operation: Get Reference Tables
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Filter<br></td><td>Specify the parameters to be used to filter (restrict) the list of reference tables to be returned by this operation in the response.<br>
+</td></tr><tr><td>Limit<br></td><td>Specify the maximum count of reference tables to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.<br>
+</td></tr><tr><td>Fields<br></td><td>Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "key_name_types": {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        "port": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        "source_ip": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        "timestamp": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    },
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": ""
+</code><code><br>}</code>
+
+### operation: Delete or Purge Reference Table
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Reference Table Name<br></td><td>Specify the name of the reference table that you want to delete from QRadar.<br>
+</td></tr><tr><td>Purge Table<br></td><td>Select the 'true' option from the Purge Table drop-down list if you want to have the contents of the specified reference table to be purged from QRadar, i.e., in this case, the structure of the specified reference table is retained. Select the 'false' (default) option from the Purge Table drop-down list to purge the contents of the specified reference table, i.e., in this case, the specified reference table is completely removed.<br>
+</td></tr><tr><td>Fields<br></td><td>(Optional) Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Namespace<br></td><td>(Optional) Specify the namespace of the reference table that you want to delete from QRadar. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "created_by": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "created": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "modified": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "started": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "completed": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "message": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "status": ""
+</code><code><br>}</code>
+
+### operation: Get Table Elements
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Reference Table Name<br></td><td>Specify the name of the reference table whose record details (elements) you want to retrieve from QRadar.<br>
+</td></tr><tr><td>Limit<br></td><td>(Optional) Specify the maximum count of table elements to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.<br>
+</td></tr><tr><td>Fields<br></td><td>(Optional) Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Namespace<br></td><td>(Optional) Specify the namespace of the reference table whose record details (elements) you want to retrieve from QRadar. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "data": {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        "outer_key": {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "inner_key": {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                "last_seen": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                "first_seen": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                "source": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                "value": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    },
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "key_name_types": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": ""
+</code><code><br>}</code>
+
+### operation: Add or Update Table Element
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Reference Table Name<br></td><td>Specify the name of the reference table in which you want to add or update the specified element.<br>
+</td></tr><tr><td>Outer Key<br></td><td>Specify the outer key in which you want to add or update the specified element.<br>
+</td></tr><tr><td>Inner Key<br></td><td>Specify the inner key in which you want to add or update the specified element.<br>
+</td></tr><tr><td>Value<br></td><td>Specify the value of the element that you want to add or update in the specified reference table. Note: Date values must be represented in Unix Epoch milliseconds.<br>
+</td></tr><tr><td>Domain ID<br></td><td>(Optional) In the case of MSSP setups, you can specify the domain ID to be set for the 'value' you have specified in the 'Value' field. If the 'Domain ID' field is null, then the shared domain is used.<br>
+</td></tr><tr><td>Element Source<br></td><td>(Optional) Specify the source of the specified element that you want to add or update in the specified table. By default, this is set to 'FortiSOAR'.<br>
+</td></tr><tr><td>Fields<br></td><td>(Optional) Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Namespace<br></td><td>(Optional) Specify the namespace of the reference table in which you want to add or update the specified element. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "key_name_types": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": ""
+</code><code><br>}</code>
+
+### operation: Delete Table Element
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Reference Table Name<br></td><td>Specify the name of the reference table from which you want to delete the specified element.<br>
+</td></tr><tr><td>Outer Key<br></td><td>Specify the outer key from which you want to delete the specified element.<br>
+</td></tr><tr><td>Inner Key<br></td><td>Specify the inner key from which you want to delete the specified element.<br>
+</td></tr><tr><td>value<br></td><td>Specify the value of the element that you want to delete from the specified reference table. Note: Date values must be represented in Epoch milliseconds.<br>
+</td></tr><tr><td>Domain ID<br></td><td>(Optional) In the case of MSSP setups, you can specify the domain ID to be set for the 'value' you have specified in the 'Value' field. If the 'Domain ID' field is null, then the shared domain is used.<br>
+</td></tr><tr><td>Fields<br></td><td>(Optional) Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.<br>
+</td></tr><tr><td>Namespace<br></td><td>(Optional) Specify the namespace of the reference table from which you want to delete the specified element. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "timeout_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "number_of_elements": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "creation_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "key_name_types": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "element_type": ""
+</code><code><br>}</code>
+
+### operation: Fetch Offenses from QRadar
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>Filter String<br></td><td>Specify the filter string based on which to retrieve the list of offenses from QRadar. For example, assigned_to="admin".<br>
+</td></tr><tr><td>Created After<br></td><td>Select the date and time using which to filter the result set to only include items that have been created after the specified timestamp.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "rules": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "type": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "status": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "inactive": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "severity": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "domain_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "follow_up": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "protected": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "relevance": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "categories": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "close_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "flow_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "start_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "assigned_to": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "credibility": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "description": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "event_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "log_sources": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "type_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "type_name": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_user": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "device_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_type": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "offense_source": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "username_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "closing_reason_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "last_updated_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_address_ids": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "last_persisted_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "destination_networks": [],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "first_persisted_time": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "policy_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "source_address_details": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "source_ip": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "security_category_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "remote_destination_count": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "destination_address_details": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "network": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "magnitude": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "local_destination_ip": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ],
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "local_destination_address_ids": []
+</code><code><br>}</code>
+
+### operation: Get Mitre Mapping Related To Offense
+#### Input parameters
+<table border=1><thead><tr><th>Parameter<br></th><th>Description<br></th></tr></thead><tbody><tr><td>QRadar Offense ID<br></td><td>Specify the Offense ID based on which you want to retrieve mitre mapping from QRadar.<br>
+</td></tr></tbody></table>
+
+#### Output
+The output contains the following populated JSON schema:
+<code><br>{
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "rule_name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "override_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "has_ibm_default": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "last_updated": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "min_mitre_version": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    "mapping": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "tactic_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "tactic_name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "confidence": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "user_override": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "enabled": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "ibm_default": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            "techniques": [
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                {
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "technique_id": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "technique_name": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "confidence": "",
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                    "enabled": ""
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;                }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;            ]
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;        }
+</code><code><br>&nbsp;&nbsp;&nbsp;&nbsp;    ]
+</code><code><br>}</code>
+
+## Included playbooks
+The `Sample - qradar - 1.6.3` playbook collection comes bundled with the IBM QRadar connector. These playbooks contain steps using which you can perform all supported actions. You can see bundled playbooks in the **Automation** > **Playbooks** section in FortiSOAR<sup>TM</sup> after importing the IBM QRadar connector.
+
+- Add or Update Table Element
+- Close Offense
+- Create Case
+- Create Note
+- Delete Table Element
+- Delete or Purge Reference Table
+- Fetch Offenses from QRadar
+- Get Assets
+- Get Assets Properties
+- Get Cases
+- Get Destination IP Addresses
+- Get Events Related to an Offense
+- Get Mitre Mapping Related To Offense
+- Get Offense Closing Reasons
+- Get Offense Notes
+- Get Offense Types
+- Get Offenses from QRadar
+- Get Reference Tables
+- Get Source IP Addresses
+- Get Table Elements
+- Invoke QRadar REST API
+- Make an Ariel Query to QRadar
+- Manipulate Reference Set Content
+- Update Asset
+
+**Note**: If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.
+## Data Ingestion Support
+Use the Data Ingestion Wizard to easily ingest data into FortiSOAR&trade; by pulling events/alerts/incidents, based on the requirement.
+
+**TODO:** provide the list of steps to configure the ingestion with the screen shots and limitations if any in this section.

--- a/qradar/funcs.py
+++ b/qradar/funcs.py
@@ -172,6 +172,22 @@ def delete_record(config, params, *args, **kwargs):
     qradar_connection = QradarConnection(**config)
     return qradar_connection.delete_record(params)
 
+def get_mitre_mapping_related_to_an_offense(config, params, *args, **kwargs):
+    headers = params.get('headers') if params.get('headers', {}) else {}
+    qradar_connection = QradarConnection(**config)
+    # Get offense analysis for rule id
+    offense_id=params['offense_id']
+    offense_details_endpoint = '/siem/offenses/' + offense_id
+    offense_res = qradar_connection.invokeQRadarAPI(endpoint=offense_details_endpoint, method='GET', params=params, headers=headers)
+    # Get rule analysis for rule uuid
+    rule_id = offense_res['rules'][0]['id']
+    rule_analysis_endpoint = '/analytics/rules/' + str(rule_id)
+
+    rule_res = qradar_connection.invokeQRadarAPI(endpoint=rule_analysis_endpoint, method='GET', params=params, headers=headers)
+    rule_uuid = rule_res['identifier']
+    qradar_connection = QradarConnection(**config)
+    return qradar_connection.get_mitre_mapping_for_offense(params, rule_uuid)
+
 
 operations = {
     'get_offenses': get_offenses,
@@ -196,5 +212,6 @@ operations = {
     'get_table_elements': get_record,
     'add_table_element': update_record,
     'delete_table_element': delete_record,
-    'fetch_offenses': fetch_offenses
+    'fetch_offenses': fetch_offenses,
+    'get_mitre_mapping_related_to_an_offense': get_mitre_mapping_related_to_an_offense
 }

--- a/qradar/info.json
+++ b/qradar/info.json
@@ -1,7 +1,7 @@
 {
   "name": "qradar",
   "label": "IBM QRadar",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "IBM QRadar is an enterprise security information and event management (SIEM) product. Fortinet FortiSOAR connector for IBM QRadar allows users to invoke QRadar API, perform Ariel Queries and operations like Get Offense,related events,update and close offenses.",
   "publisher": "Fortinet",
   "cs_approved": true,
@@ -13,7 +13,7 @@
   "ingestion_modes": [
     "scheduled"
   ],
-  "help_online": "https://docs.fortinet.com/document/fortisoar/1.6.2/ibm-qradar/1003/ibm-qradar-v1-6-2",
+  "help_online": "",
   "configuration": {
     "fields": [
       {
@@ -25,7 +25,8 @@
         "name": "address",
         "value": "",
         "description": "Specify the IP address of the QRadar server from where the connector gets offenses information and to which you connect and perform automated operations.",
-        "tooltip": "Specify the IP address of the QRadar server from where the connector gets offenses information and to which you connect and perform automated operations."
+        "tooltip": "Specify the IP address of the QRadar server from where the connector gets offenses information and to which you connect and perform automated operations.",
+        "isOnChange": false
       },
       {
         "title": "API Token",
@@ -35,7 +36,8 @@
         "type": "password",
         "name": "token",
         "description": "Specify the API token to access the QRadar server to which you connect and perform automated operations.",
-        "tooltip": "Specify the API token to access the QRadar server to which you connect and perform automated operations."
+        "tooltip": "Specify the API token to access the QRadar server to which you connect and perform automated operations.",
+        "isOnChange": false
       },
       {
         "title": "API Version",
@@ -46,7 +48,8 @@
         "name": "api_version",
         "value": "14.0",
         "description": "Specify the version of the QRadar API to be used for performing automated operations. By default, this is set to 14.0.",
-        "tooltip": "Specify the version of the QRadar API to be used for performing automated operations. By default, this is set to 14.0."
+        "tooltip": "Specify the version of the QRadar API to be used for performing automated operations. By default, this is set to 14.0.",
+        "isOnChange": false
       },
       {
         "title": "Verify SSL",
@@ -57,7 +60,8 @@
         "name": "verify_ssl",
         "value": true,
         "description": "Specifies whether the SSL certificate for the server is to be verified. By default, this is set to True.",
-        "tooltip": "Specifies whether the SSL certificate for the server is to be verified. By default, this is set to True."
+        "tooltip": "Specifies whether the SSL certificate for the server is to be verified. By default, this is set to True.",
+        "isOnChange": false
       }
     ]
   },
@@ -68,6 +72,21 @@
       "description": "Retrieves a list of offenses from the QRadar server based on the filter string that you have specified.",
       "category": "investigation",
       "annotation": "get_offenses",
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Filter String",
+          "description": "Specify the filter string based on which you want to retrieve the list of offenses from QRadar. For example, assigned_to\u003d\"admin\".",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "filter_string",
+          "value": "status\u003d\"OPEN\"",
+          "tooltip": "Specify the filter string based on which you want to retrieve the list of offenses from QRadar. For example, assigned_to\u003d\"admin\".",
+          "placeholder": "For e.g. status\u003dOPEN"
+        }
+      ],
       "output_schema": [
         {
           "credibility": "",
@@ -105,21 +124,6 @@
           "categories": [],
           "offense_type": ""
         }
-      ],
-      "enabled": true,
-      "parameters": [
-        {
-          "title": "Filter String",
-          "description": "Specify the filter string based on which you want to retrieve the list of offenses from QRadar. For example, assigned_to=\"admin\".",
-          "required": true,
-          "editable": true,
-          "visible": true,
-          "type": "text",
-          "name": "filter_string",
-          "value": "status=\"OPEN\"",
-          "tooltip": "Specify the filter string based on which you want to retrieve the list of offenses from QRadar. For example, assigned_to=\"admin\".",
-          "placeholder": "For e.g. status=OPEN"
-        }
       ]
     },
     {
@@ -128,7 +132,6 @@
       "description": "Executes an Ariel query on the QRadar server. QRadar uses the Ariel Query Language (AQL) to search for offenses or events based on query parameters.",
       "category": "investigation",
       "annotation": "run_query",
-      "output_schema": {},
       "enabled": true,
       "parameters": [
         {
@@ -140,10 +143,10 @@
           "type": "text",
           "name": "search_string",
           "tooltip": "Specify the Ariel query that you want to run on the QRadar server.",
-          "placeholder": "For e.g. SELECT sourceip, starttime, qid, sourceport  from events",
-          "value": null
+          "placeholder": "For e.g. SELECT sourceip, starttime, qid, sourceport  from events"
         }
-      ]
+      ],
+      "output_schema": {}
     },
     {
       "operation": "get_closing_reasons",
@@ -151,6 +154,8 @@
       "description": "Retrieves a list of closing reasons associated with all offenses from the QRadar server.",
       "category": "remediation",
       "annotation": "get_offense_closing_reasons",
+      "enabled": true,
+      "parameters": [],
       "output_schema": [
         {
           "is_deleted": "",
@@ -158,9 +163,7 @@
           "is_reserved": "",
           "text": ""
         }
-      ],
-      "enabled": true,
-      "parameters": []
+      ]
     },
     {
       "operation": "get_offense_type",
@@ -168,6 +171,8 @@
       "description": "Retrieves a list containing IDs of all the offense types from the QRadar server.",
       "category": "investigation",
       "annotation": "get_offense_type",
+      "enabled": true,
+      "parameters": [],
       "output_schema": [
         {
           "property_name": "",
@@ -176,9 +181,7 @@
           "name": "",
           "custom": ""
         }
-      ],
-      "enabled": true,
-      "parameters": []
+      ]
     },
     {
       "operation": "get_notes",
@@ -186,14 +189,6 @@
       "description": "Retrieves a list of notes associated with a specified offense in QRadar based on the offense ID you have specified.",
       "category": "remediation",
       "annotation": "get_notes",
-      "output_schema": [
-        {
-          "id": "",
-          "note_text": "",
-          "create_time": "",
-          "username": ""
-        }
-      ],
       "enabled": true,
       "parameters": [
         {
@@ -204,8 +199,15 @@
           "visible": true,
           "type": "text",
           "name": "offense_id",
-          "tooltip": "Specify the ID of the offense whose associated notes you want to retrieve from the QRadar server.",
-          "value": null
+          "tooltip": "Specify the ID of the offense whose associated notes you want to retrieve from the QRadar server."
+        }
+      ],
+      "output_schema": [
+        {
+          "id": "",
+          "note_text": "",
+          "create_time": "",
+          "username": ""
         }
       ]
     },
@@ -215,6 +217,39 @@
       "description": "Closes an offense on the QRadar server based on the offense ID that you have specified.",
       "category": "remediation",
       "annotation": "close_offense",
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Offense ID",
+          "description": "Specify the ID of the offense that you want to close on the QRadar server.",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "offense_id",
+          "tooltip": "Specify the ID of the offense that you want to close on the QRadar server."
+        },
+        {
+          "title": "Offense Closing Reason - ID",
+          "description": "Specify the ID of the offense closing reason using which you want to close the offense on the QRadar server.",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "offense_close_id",
+          "tooltip": "Specify the ID of the offense closing reason using which you want to close the offense on the QRadar server."
+        },
+        {
+          "title": "Closure Note",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "textarea",
+          "name": "closure_note",
+          "description": "(Optional) Note that you want to associate with the offense that you want to close on the QRadar server.",
+          "tooltip": "(Optional) Note that you want to associate with the offense that you want to close on the QRadar server."
+        }
+      ],
       "output_schema": {
         "credibility": "",
         "source_address_ids": [],
@@ -250,43 +285,7 @@
         "last_updated_time": "",
         "categories": [],
         "offense_type": ""
-      },
-      "enabled": true,
-      "parameters": [
-        {
-          "title": "Offense ID",
-          "description": "Specify the ID of the offense that you want to close on the QRadar server.",
-          "required": true,
-          "editable": true,
-          "visible": true,
-          "type": "text",
-          "name": "offense_id",
-          "tooltip": "Specify the ID of the offense that you want to close on the QRadar server.",
-          "value": null
-        },
-        {
-          "title": "Offense Closing Reason - ID",
-          "description": "Specify the ID of the offense closing reason using which you want to close the offense on the QRadar server.",
-          "required": true,
-          "editable": true,
-          "visible": true,
-          "type": "text",
-          "name": "offense_close_id",
-          "tooltip": "Specify the ID of the offense closing reason using which you want to close the offense on the QRadar server.",
-          "value": null
-        },
-        {
-          "title": "Closure Note",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "type": "textarea",
-          "name": "closure_note",
-          "value": null,
-          "description": "(Optional) Note that you want to associate with the offense that you want to close on the QRadar server.",
-          "tooltip": "(Optional) Note that you want to associate with the offense that you want to close on the QRadar server."
-        }
-      ]
+      }
     },
     {
       "operation": "add_notes",
@@ -294,12 +293,6 @@
       "description": "Creates a note for a specified offense in QRadar based on the offense ID you have specified.",
       "category": "remediation",
       "annotation": "add_notes",
-      "output_schema": {
-        "id": "",
-        "note_text": "",
-        "create_time": "",
-        "username": ""
-      },
       "enabled": true,
       "parameters": [
         {
@@ -310,8 +303,7 @@
           "visible": true,
           "type": "text",
           "name": "offense_id",
-          "tooltip": "Specify the ID of the offense for which you want to create a note on the QRadar server.",
-          "value": null
+          "tooltip": "Specify the ID of the offense for which you want to create a note on the QRadar server."
         },
         {
           "title": "Closure Note",
@@ -321,10 +313,15 @@
           "visible": true,
           "type": "textarea",
           "name": "closure_note",
-          "tooltip": "Specify the text of the closure note that you want to create for the specified offense on the QRadar server.",
-          "value": null
+          "tooltip": "Specify the text of the closure note that you want to create for the specified offense on the QRadar server."
         }
-      ]
+      ],
+      "output_schema": {
+        "id": "",
+        "note_text": "",
+        "create_time": "",
+        "username": ""
+      }
     },
     {
       "operation": "get_events_related_to_offense",
@@ -332,25 +329,6 @@
       "description": "Retrieves details of events associated with a QRadar offense, from the QRadar server, based on the QRadar offense ID that you have specified.",
       "category": "investigation",
       "annotation": "get_events",
-      "output_schema": {
-        "events": [
-          {
-            "qid": "",
-            "category": "",
-            "sourceip": "",
-            "username": "",
-            "magnitude": "",
-            "starttime": "",
-            "eventcount": "",
-            "identityip": "",
-            "protocolid": "",
-            "sourceport": "",
-            "logsourceid": "",
-            "destinationip": "",
-            "destinationport": ""
-          }
-        ]
-      },
       "enabled": true,
       "parameters": [
         {
@@ -397,18 +375,31 @@
           "tooltip": "(Optional) Specify the maximum number of events that this operation should return.",
           "value": 100
         }
-      ]
+      ],
+      "output_schema": {
+        "events": [
+          {
+            "qid": "",
+            "category": "",
+            "sourceip": "",
+            "username": "",
+            "magnitude": "",
+            "starttime": "",
+            "eventcount": "",
+            "identityip": "",
+            "protocolid": "",
+            "sourceport": "",
+            "logsourceid": "",
+            "destinationip": "",
+            "destinationport": ""
+          }
+        ]
+      }
     },
     {
       "operation": "get_source_ip",
       "title": "Get Source IP Addresses",
       "description": "Retrieves IP address details associated with source address IDs from the QRadar server, based on the source address IDs that you have specified",
-      "output_schema": {
-        "id": "",
-        "source_ip": "",
-        "network": "",
-        "magnitude": ""
-      },
       "category": "investigation",
       "annotation": "ip_details",
       "enabled": true,
@@ -423,7 +414,13 @@
           "name": "source_address_ids",
           "tooltip": "Specify the IDs of source addresses based on which you want to retrieve IP address details from the QRadar server. For example, [3,4,5]."
         }
-      ]
+      ],
+      "output_schema": {
+        "id": "",
+        "source_ip": "",
+        "network": "",
+        "magnitude": ""
+      }
     },
     {
       "operation": "get_destination_ip",
@@ -431,12 +428,6 @@
       "description": "Retrieves IP address details associated with the destination address IDs from the QRadar server, based on the destination address IDs that you have specified",
       "category": "investigation",
       "annotation": "ip_details",
-      "output_schema": {
-        "id": "",
-        "local_destination_ip": "",
-        "network": "",
-        "magnitude": ""
-      },
       "enabled": true,
       "parameters": [
         {
@@ -449,7 +440,13 @@
           "name": "destination_address_ids",
           "tooltip": "IDs of destination addresses based on which you want to retrieve IP address details from the QRadar server. For example, [3,4,5]."
         }
-      ]
+      ],
+      "output_schema": {
+        "id": "",
+        "local_destination_ip": "",
+        "network": "",
+        "magnitude": ""
+      }
     },
     {
       "operation": "invoke_api",
@@ -457,7 +454,6 @@
       "category": "investigation",
       "annotation": "api_call",
       "description": "Invokes a function to Get or Post an API endpoint on the QRadar server.",
-      "output_schema": {},
       "enabled": true,
       "parameters": [
         {
@@ -496,7 +492,10 @@
                 "visible": true,
                 "type": "json",
                 "name": "request_parameters",
-                "tooltip": "Provide the request parameters for the above endpoint that you have specified"
+                "tooltip": "Provide the request parameters for the above endpoint that you have specified",
+                "isOnChange": true,
+                "onChangeParam": "Request Method",
+                "onChangeOption": "GET"
               }
             ],
             "POST": [
@@ -521,7 +520,10 @@
                       "visible": true,
                       "type": "json",
                       "name": "request_parameters",
-                      "tooltip": "Provide the request parameters for the above endpoint that you have specified"
+                      "tooltip": "Provide the request parameters for the above endpoint that you have specified",
+                      "isOnChange": true,
+                      "onChangeParam": "Provide Parameters",
+                      "onChangeOption": "Request Parameters"
                     }
                   ],
                   "Request Payload": [
@@ -533,10 +535,16 @@
                       "visible": true,
                       "type": "json",
                       "name": "request_payload",
-                      "tooltip": "Provide the request json payload for the above endpoint that you have specified"
+                      "tooltip": "Provide the request json payload for the above endpoint that you have specified",
+                      "isOnChange": true,
+                      "onChangeParam": "Provide Parameters",
+                      "onChangeOption": "Request Payload"
                     }
                   ]
-                }
+                },
+                "isOnChange": true,
+                "onChangeParam": "Request Method",
+                "onChangeOption": "POST"
               }
             ],
             "PATCH": [
@@ -561,7 +569,10 @@
                       "visible": true,
                       "type": "json",
                       "name": "request_parameters",
-                      "tooltip": "Provide the request parameters for the above endpoint that you have specified"
+                      "tooltip": "Provide the request parameters for the above endpoint that you have specified",
+                      "isOnChange": true,
+                      "onChangeParam": "Provide Parameters",
+                      "onChangeOption": "Request Parameters"
                     }
                   ],
                   "Request Payload": [
@@ -573,10 +584,16 @@
                       "visible": true,
                       "type": "json",
                       "name": "request_payload",
-                      "tooltip": "Provide the request json payload for the above endpoint that you have specified"
+                      "tooltip": "Provide the request json payload for the above endpoint that you have specified",
+                      "isOnChange": true,
+                      "onChangeParam": "Provide Parameters",
+                      "onChangeOption": "Request Payload"
                     }
                   ]
-                }
+                },
+                "isOnChange": true,
+                "onChangeParam": "Request Method",
+                "onChangeOption": "PATCH"
               }
             ]
           }
@@ -584,14 +601,15 @@
         {
           "title": "Headers in json format",
           "required": false,
-          "description": "(Optional) Additional JSON formatted headers. The following headers are already added by the connector: 'Accept': 'application/JSON', 'Content-Type': 'application/JSON', 'SEC': <token>, 'Version': <api_version>,",
+          "description": "(Optional) Additional JSON formatted headers. The following headers are already added by the connector: \u0027Accept\u0027: \u0027application/JSON\u0027, \u0027Content-Type\u0027: \u0027application/JSON\u0027, \u0027SEC\u0027: \u003ctoken\u003e, \u0027Version\u0027: \u003capi_version\u003e,",
           "editable": true,
           "visible": true,
           "type": "json",
           "name": "headers",
-          "tooltip": "(Optional) Additional JSON formatted headers. The following headers are already added by the connector: 'Accept': 'application/JSON', 'Content-Type': 'application/JSON', 'SEC': <token>, 'Version': <api_version>,"
+          "tooltip": "(Optional) Additional JSON formatted headers. The following headers are already added by the connector: \u0027Accept\u0027: \u0027application/JSON\u0027, \u0027Content-Type\u0027: \u0027application/JSON\u0027, \u0027SEC\u0027: \u003ctoken\u003e, \u0027Version\u0027: \u003capi_version\u003e,"
         }
-      ]
+      ],
+      "output_schema": {}
     },
     {
       "operation": "handle_reference_set_value",
@@ -601,7 +619,7 @@
       "description": "Adds or deletes the content that you have specified from a reference set on QRadar.",
       "conditional_output_schema": [
         {
-          "condition": "{{method === 'Retrieves Value'}}",
+          "condition": "{{method \u003d\u003d\u003d \u0027Retrieves Value\u0027}}",
           "output_schema": {
             "data": [
               {
@@ -620,7 +638,7 @@
           }
         },
         {
-          "condition": "{{(method === 'Add Value' || method === 'Delete Value')}}",
+          "condition": "{{(method \u003d\u003d\u003d \u0027Add Value\u0027 || method \u003d\u003d\u003d \u0027Delete Value\u0027)}}",
           "output_schema": {
             "message": "",
             "element_type": "",
@@ -658,7 +676,10 @@
                 "editable": true,
                 "visible": true,
                 "type": "text",
-                "name": "name"
+                "name": "name",
+                "isOnChange": true,
+                "onChangeParam": "Request Method",
+                "onChangeOption": "Retrieves Value"
               }
             ],
             "Add Value": [
@@ -670,7 +691,10 @@
                 "editable": true,
                 "visible": true,
                 "type": "text",
-                "name": "name"
+                "name": "name",
+                "isOnChange": true,
+                "onChangeParam": "Request Method",
+                "onChangeOption": "Add Value"
               },
               {
                 "title": "Value",
@@ -680,7 +704,10 @@
                 "editable": true,
                 "visible": true,
                 "type": "text",
-                "name": "value"
+                "name": "value",
+                "isOnChange": true,
+                "onChangeParam": "Request Method",
+                "onChangeOption": "Add Value"
               }
             ],
             "Delete Value": [
@@ -692,7 +719,10 @@
                 "editable": true,
                 "visible": true,
                 "type": "text",
-                "name": "name"
+                "name": "name",
+                "isOnChange": true,
+                "onChangeParam": "Request Method",
+                "onChangeOption": "Delete Value"
               },
               {
                 "title": "Value",
@@ -702,7 +732,10 @@
                 "editable": true,
                 "visible": true,
                 "type": "text",
-                "name": "value"
+                "name": "value",
+                "isOnChange": true,
+                "onChangeParam": "Request Method",
+                "onChangeOption": "Delete Value"
               }
             ]
           }
@@ -715,16 +748,6 @@
       "description": "Retrieves a detailed list of available asset properties or specific available asset properties from QRadar based on input parameters specified.",
       "category": "investigation",
       "annotation": "get_assets_properties",
-      "output_schema": [
-        {
-          "data_type": "",
-          "display": "",
-          "custom": "",
-          "name": "",
-          "id": "",
-          "state": ""
-        }
-      ],
       "enabled": true,
       "parameters": [
         {
@@ -747,7 +770,7 @@
           "visible": true,
           "type": "text",
           "name": "filter_string",
-          "placeholder": "field_one = 'some_string' and field_two > 42 or not field_three in (1, 2, 3)",
+          "placeholder": "field_one \u003d \u0027some_string\u0027 and field_two \u003e 42 or not field_three in (1, 2, 3)",
           "value": ""
         },
         {
@@ -762,6 +785,16 @@
           "placeholder": "field_one(sub_field_one,sub_field_two),field_two",
           "value": ""
         }
+      ],
+      "output_schema": [
+        {
+          "data_type": "",
+          "display": "",
+          "custom": "",
+          "name": "",
+          "id": "",
+          "state": ""
+        }
       ]
     },
     {
@@ -770,6 +803,56 @@
       "description": "Retrieves a detailed list of all available assets or specific available assets from QRadar based on input parameters specified.",
       "category": "investigation",
       "annotation": "get_assets",
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Filter",
+          "description": "Specify the parameters to be used to filter (restrict) the list of assets to be returned by this operation in the response.",
+          "tooltip": "This parameter is used to restrict the list of assets in the response based on the filter query specified.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "filter_string",
+          "placeholder": "field_one \u003d \u0027some_string\u0027 and field_two \u003e 42 or not field_three in (1, 2, 3)",
+          "value": ""
+        },
+        {
+          "title": "Limit",
+          "description": "Specify the maximum count of assets to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.",
+          "tooltip": "Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "integer",
+          "name": "max_results",
+          "value": 100
+        },
+        {
+          "title": "Fields",
+          "description": "Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.",
+          "tooltip": "Use this parameter to specify which fields you would like to get back in the response. Fields that are not named are excluded. Specify subfields in brackets and multiple fields in the same object are separated by commas.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "query.fields",
+          "placeholder": "field_one(sub_field_one,sub_field_two),field_two",
+          "value": ""
+        },
+        {
+          "title": "Sort",
+          "description": "Specify the fields using which you want to sort the response. Specify the negative (-) sign to sort the results in descending order and the positive sign (+) to sort in ascending order.",
+          "tooltip": "Use this parameter to specify on which field you would like to sort the response. Specify negative sign to sort in descending order and positive sign to sort in ascending order.",
+          "required": false,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "query.sort",
+          "placeholder": "-id",
+          "value": ""
+        }
+      ],
       "output_schema": [
         {
           "vulnerability_count": "",
@@ -814,65 +897,14 @@
           ],
           "products": ""
         }
-      ],
-      "enabled": true,
-      "parameters": [
-        {
-          "title": "Filter",
-          "description": "Specify the parameters to be used to filter (restrict) the list of assets to be returned by this operation in the response.",
-          "tooltip": "This parameter is used to restrict the list of assets in the response based on the filter query specified.",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "type": "text",
-          "name": "filter_string",
-          "placeholder": "field_one = 'some_string' and field_two > 42 or not field_three in (1, 2, 3)",
-          "value": ""
-        },
-        {
-          "title": "Limit",
-          "description": "Specify the maximum count of assets to be returned by this operation in the response. Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.",
-          "tooltip": "Use this parameter to restrict the number of elements that are returned in the list to a specified range. The list is indexed starting at zero.",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "type": "integer",
-          "name": "max_results",
-          "value": 100
-        },
-        {
-          "title": "Fields",
-          "description": "Specify the fields to be returned in the response. Fields that are not named are excluded. Specify subfields in brackets, and multiple fields in the same object are separated by commas.",
-          "tooltip": "Use this parameter to specify which fields you would like to get back in the response. Fields that are not named are excluded. Specify subfields in brackets and multiple fields in the same object are separated by commas.",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "type": "text",
-          "name": "query.fields",
-          "placeholder": "field_one(sub_field_one,sub_field_two),field_two",
-          "value": ""
-        },
-        {
-          "title": "Sort",
-          "description": "Specify the fields using which you want to sort the response. Specify the negative (-) sign to sort the results in descending order and the positive sign (+) to sort in ascending order.",
-          "tooltip": "Use this parameter to specify on which field you would like to sort the response. Specify negative sign to sort in descending order and positive sign to sort in ascending order.",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "type": "text",
-          "name": "query.sort",
-          "placeholder": "-id",
-          "value": ""
-        }
       ]
     },
     {
       "operation": "update_asset",
       "title": "Update Asset",
-      "description": "Updates the attributes of a specific asset on the QRadar server based on the asset ID and asset properties you have specified. Note: You can retrieve the list of asset properties using the 'Get Assets Properties' operation.",
+      "description": "Updates the attributes of a specific asset on the QRadar server based on the asset ID and asset properties you have specified. Note: You can retrieve the list of asset properties using the \u0027Get Assets Properties\u0027 operation.",
       "category": "investigation",
       "annotation": "update_asset",
-      "output_schema": "",
       "enabled": true,
       "parameters": [
         {
@@ -916,7 +948,8 @@
           "name": "content_type",
           "value": "text/plain"
         }
-      ]
+      ],
+      "output_schema": ""
     },
     {
       "operation": "get_cases",
@@ -924,13 +957,6 @@
       "description": "Retrieves a detailed list of all cases or specific cases from QRadar based on input parameters specified. Note: This action is supported on QRadar API version 7.0 and later.",
       "category": "investigation",
       "annotation": "get_cases",
-      "output_schema": [
-        {
-          "assigned_to": [],
-          "id": "",
-          "name": ""
-        }
-      ],
       "enabled": true,
       "parameters": [
         {
@@ -954,7 +980,7 @@
           "visible": true,
           "type": "text",
           "name": "filter_string",
-          "placeholder": "field_one = 'some_string' and field_two > 42 or not field_three in (1, 2, 3)",
+          "placeholder": "field_one \u003d \u0027some_string\u0027 and field_two \u003e 42 or not field_three in (1, 2, 3)",
           "value": ""
         },
         {
@@ -968,6 +994,13 @@
           "name": "max_results",
           "value": 100
         }
+      ],
+      "output_schema": [
+        {
+          "assigned_to": [],
+          "id": "",
+          "name": ""
+        }
       ]
     },
     {
@@ -976,13 +1009,6 @@
       "description": "Creates a new case on QRadar based on the case properties you have specified. Note: This action is supported on QRadar API version 7.0 and later.",
       "category": "investigation",
       "annotation": "create_case",
-      "output_schema": {
-        "case_id": "",
-        "name": "",
-        "id": "",
-        "state": "",
-        "assigned_to": []
-      },
       "enabled": true,
       "parameters": [
         {
@@ -1012,7 +1038,14 @@
           "name": "content_type",
           "value": "application/json"
         }
-      ]
+      ],
+      "output_schema": {
+        "case_id": "",
+        "name": "",
+        "id": "",
+        "state": "",
+        "assigned_to": []
+      }
     },
     {
       "operation": "get_reference_tables",
@@ -1020,20 +1053,6 @@
       "description": "Retrieves a detailed list of all reference tables or specific reference tables from QRadar based on input parameters specified.",
       "category": "investigation",
       "annotation": "get_reference_tables",
-      "output_schema": [
-        {
-          "timeout_type": "",
-          "number_of_elements": "",
-          "creation_time": "",
-          "name": "",
-          "key_name_types": {
-            "port": "",
-            "source_ip": "",
-            "timestamp": ""
-          },
-          "element_type": ""
-        }
-      ],
       "enabled": true,
       "parameters": [
         {
@@ -1045,7 +1064,7 @@
           "visible": true,
           "type": "text",
           "name": "filter_string",
-          "placeholder": "field_one = 'some_string' and field_two > 42 or not field_three in (1, 2, 3)",
+          "placeholder": "field_one \u003d \u0027some_string\u0027 and field_two \u003e 42 or not field_three in (1, 2, 3)",
           "value": ""
         },
         {
@@ -1071,25 +1090,28 @@
           "placeholder": "field_one(sub_field_one,sub_field_two),field_two",
           "value": ""
         }
+      ],
+      "output_schema": [
+        {
+          "timeout_type": "",
+          "number_of_elements": "",
+          "creation_time": "",
+          "name": "",
+          "key_name_types": {
+            "port": "",
+            "source_ip": "",
+            "timestamp": ""
+          },
+          "element_type": ""
+        }
       ]
     },
     {
       "operation": "delete_reference_table",
       "title": "Delete or Purge Reference Table",
-      "description": "Deletes a specific reference table and optionally purges its content from QRadar based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the 'Get Reference Tables' operation.",
+      "description": "Deletes a specific reference table and optionally purges its content from QRadar based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the \u0027Get Reference Tables\u0027 operation.",
       "category": "investigation",
       "annotation": "delete_reference_table",
-      "output_schema": {
-        "created_by": "",
-        "created": "",
-        "name": "",
-        "modified": "",
-        "started": "",
-        "completed": "",
-        "id": "",
-        "message": "",
-        "status": ""
-      },
       "enabled": true,
       "parameters": [
         {
@@ -1109,7 +1131,7 @@
           "editable": true,
           "visible": true,
           "type": "select",
-          "description": "Select the 'true' option from the Purge Table drop-down list if you want to have the contents of the specified reference table to be purged from QRadar, i.e., in this case, the structure of the specified reference table is retained. Select the 'false' (default) option from the Purge Table drop-down list to purge the contents of the specified reference table, i.e., in this case, the specified reference table is completely removed.",
+          "description": "Select the \u0027true\u0027 option from the Purge Table drop-down list if you want to have the contents of the specified reference table to be purged from QRadar, i.e., in this case, the structure of the specified reference table is retained. Select the \u0027false\u0027 (default) option from the Purge Table drop-down list to purge the contents of the specified reference table, i.e., in this case, the specified reference table is completely removed.",
           "tooltip": "This indicates if the reference table should have its contents purged (if the value is true), keeping the reference table structure. If the value is false, or not specified the reference table is removed completely.",
           "options": [
             "true",
@@ -1132,7 +1154,7 @@
         },
         {
           "title": "Namespace",
-          "description": "(Optional) Specify the namespace of the reference table that you want to delete from QRadar. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users.",
+          "description": "(Optional) Specify the namespace of the reference table that you want to delete from QRadar. By default, it is \u0027SHARED\u0027 for \u0027admin\u0027 users and \u0027TENANT\u0027 for \u0027tenant\u0027 users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is \u0027SHARED\u0027 for all users.",
           "tooltip": "Specify the namespace, Default is SHARED for admin users and TENANT for tenant users. If purge_only is true, the default is SHARED for all users.",
           "required": false,
           "editable": true,
@@ -1141,32 +1163,25 @@
           "name": "query.namespace",
           "value": ""
         }
-      ]
+      ],
+      "output_schema": {
+        "created_by": "",
+        "created": "",
+        "name": "",
+        "modified": "",
+        "started": "",
+        "completed": "",
+        "id": "",
+        "message": "",
+        "status": ""
+      }
     },
     {
       "operation": "get_table_elements",
       "title": "Get Table Elements",
-      "description": "Retrieves the record details (elements) of a specific reference table based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the 'Get Reference Tables' operation.",
+      "description": "Retrieves the record details (elements) of a specific reference table based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the \u0027Get Reference Tables\u0027 operation.",
       "category": "investigation",
       "annotation": "get_table_elements",
-      "output_schema": {
-        "timeout_type": "",
-        "number_of_elements": "",
-        "data": {
-          "outer_key": {
-            "inner_key": {
-              "last_seen": "",
-              "first_seen": "",
-              "source": "",
-              "value": ""
-            }
-          }
-        },
-        "creation_time": "",
-        "name": "",
-        "key_name_types": "",
-        "element_type": ""
-      },
       "enabled": true,
       "parameters": [
         {
@@ -1205,7 +1220,7 @@
         },
         {
           "title": "Namespace",
-          "description": "(Optional) Specify the namespace of the reference table whose record details (elements) you want to retrieve from QRadar. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users.",
+          "description": "(Optional) Specify the namespace of the reference table whose record details (elements) you want to retrieve from QRadar. By default, it is \u0027SHARED\u0027 for \u0027admin\u0027 users and \u0027TENANT\u0027 for \u0027tenant\u0027 users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is \u0027SHARED\u0027 for all users.",
           "tooltip": "Specify the namespace, Default is SHARED for admin users and TENANT for tenant users. If purge_only is true, the default is SHARED for all users.",
           "required": false,
           "editable": true,
@@ -1214,7 +1229,25 @@
           "name": "query.namespace",
           "value": ""
         }
-      ]
+      ],
+      "output_schema": {
+        "timeout_type": "",
+        "number_of_elements": "",
+        "data": {
+          "outer_key": {
+            "inner_key": {
+              "last_seen": "",
+              "first_seen": "",
+              "source": "",
+              "value": ""
+            }
+          }
+        },
+        "creation_time": "",
+        "name": "",
+        "key_name_types": "",
+        "element_type": ""
+      }
     },
     {
       "operation": "add_table_element",
@@ -1222,14 +1255,6 @@
       "description": "Adds or updates an element in the specified reference table based on the reference table name, outer key, inner key, and other input parameters you have specified.",
       "category": "investigation",
       "annotation": "add_table_element",
-      "output_schema": {
-        "timeout_type": "",
-        "number_of_elements": "",
-        "creation_time": "",
-        "name": "",
-        "key_name_types": "",
-        "element_type": ""
-      },
       "enabled": true,
       "parameters": [
         {
@@ -1282,7 +1307,7 @@
         },
         {
           "title": "Domain ID",
-          "description": "(Optional) In the case of MSSP setups, you can specify the domain ID to be set for the 'value' you have specified in the 'Value' field. If the 'Domain ID' field is null, then the shared domain is used.",
+          "description": "(Optional) In the case of MSSP setups, you can specify the domain ID to be set for the \u0027value\u0027 you have specified in the \u0027Value\u0027 field. If the \u0027Domain ID\u0027 field is null, then the shared domain is used.",
           "tooltip": "For MSSP setups, it sets the domain id for the value to be specified. If null, the shared domain will be used.",
           "required": false,
           "editable": true,
@@ -1293,8 +1318,8 @@
         },
         {
           "title": "Element Source",
-          "description": "(Optional) Specify the source of the specified element that you want to add or update in the specified table. By default, this is set to 'FortiSOAR'.",
-          "tooltip": "An indication of where the data originated. The default value is 'FortiSOAR'",
+          "description": "(Optional) Specify the source of the specified element that you want to add or update in the specified table. By default, this is set to \u0027FortiSOAR\u0027.",
+          "tooltip": "An indication of where the data originated. The default value is \u0027FortiSOAR\u0027",
           "required": false,
           "editable": true,
           "visible": true,
@@ -1316,7 +1341,7 @@
         },
         {
           "title": "Namespace",
-          "description": "(Optional) Specify the namespace of the reference table in which you want to add or update the specified element. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users",
+          "description": "(Optional) Specify the namespace of the reference table in which you want to add or update the specified element. By default, it is \u0027SHARED\u0027 for \u0027admin\u0027 users and \u0027TENANT\u0027 for \u0027tenant\u0027 users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is \u0027SHARED\u0027 for all users",
           "tooltip": "Specify the namespace, Default is SHARED for admin users and TENANT for tenant users. If purge_only is true, the default is SHARED for all users.",
           "required": false,
           "editable": true,
@@ -1325,14 +1350,7 @@
           "name": "query.namespace",
           "value": ""
         }
-      ]
-    },
-    {
-      "operation": "delete_table_element",
-      "title": "Delete Table Element",
-      "description": "Specify the element to be deleted from a reference table on Qradar based on the input parameters specified.",
-      "category": "investigation",
-      "annotation": "delete_table_element",
+      ],
       "output_schema": {
         "timeout_type": "",
         "number_of_elements": "",
@@ -1340,7 +1358,14 @@
         "name": "",
         "key_name_types": "",
         "element_type": ""
-      },
+      }
+    },
+    {
+      "operation": "delete_table_element",
+      "title": "Delete Table Element",
+      "description": "Specify the element to be deleted from a reference table on Qradar based on the input parameters specified.",
+      "category": "investigation",
+      "annotation": "delete_table_element",
       "enabled": true,
       "parameters": [
         {
@@ -1393,7 +1418,7 @@
         },
         {
           "title": "Domain ID",
-          "description": "(Optional) In the case of MSSP setups, you can specify the domain ID to be set for the 'value' you have specified in the 'Value' field. If the 'Domain ID' field is null, then the shared domain is used.",
+          "description": "(Optional) In the case of MSSP setups, you can specify the domain ID to be set for the \u0027value\u0027 you have specified in the \u0027Value\u0027 field. If the \u0027Domain ID\u0027 field is null, then the shared domain is used.",
           "tooltip": "For MSSP setups, it sets the domain id for the value to be specified. If null, the shared domain will be used.",
           "required": false,
           "editable": true,
@@ -1416,7 +1441,7 @@
         },
         {
           "title": "Namespace",
-          "description": "(Optional) Specify the namespace of the reference table from which you want to delete the specified element. By default, it is 'SHARED' for 'admin' users and 'TENANT' for 'tenant' users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is 'SHARED' for all users",
+          "description": "(Optional) Specify the namespace of the reference table from which you want to delete the specified element. By default, it is \u0027SHARED\u0027 for \u0027admin\u0027 users and \u0027TENANT\u0027 for \u0027tenant\u0027 users. Note: If you select true from the Purge Table drop-down list, i.e., purge_only is set to true, then the default is \u0027SHARED\u0027 for all users",
           "tooltip": "Specify the namespace, Default is SHARED for admin users and TENANT for tenant users. If purge_only is true, the default is SHARED for all users.",
           "required": false,
           "editable": true,
@@ -1425,7 +1450,15 @@
           "name": "query.namespace",
           "value": ""
         }
-      ]
+      ],
+      "output_schema": {
+        "timeout_type": "",
+        "number_of_elements": "",
+        "creation_time": "",
+        "name": "",
+        "key_name_types": "",
+        "element_type": ""
+      }
     },
     {
       "operation": "fetch_offenses",
@@ -1433,6 +1466,30 @@
       "description": "Retrieves a list of offenses from the QRadar server based on the filter string and start datetime that you have specified.",
       "category": "investigation",
       "annotation": "fetch_offenses",
+      "enabled": true,
+      "parameters": [
+        {
+          "title": "Filter String",
+          "description": "Specify the filter string based on which to retrieve the list of offenses from QRadar. For example, assigned_to\u003d\"admin\".",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "text",
+          "name": "filter_string",
+          "value": "status\u003d\"OPEN\"",
+          "tooltip": "Specify the filter string based on which to retrieve the list of offenses from QRadar. For example, assigned_to\u003d\"admin\"."
+        },
+        {
+          "title": "Created After",
+          "description": "Select the date and time using which to filter the result set to only include items that have been created after the specified timestamp.",
+          "required": true,
+          "editable": true,
+          "visible": true,
+          "type": "datetime",
+          "name": "start_time",
+          "tooltip": "Select the date and time using which to filter the result set to only include items that have been created after the specified timestamp."
+        }
+      ],
       "output_schema": [
         {
           "id": "",
@@ -1502,29 +1559,57 @@
           ],
           "local_destination_address_ids": []
         }
-      ],
+      ]
+    },
+    {
+      "operation": "get_mitre_mapping_related_to_an_offense",
+      "title": "Get Mitre Mapping Related To Offense",
+      "annotation": "get_mitre_mapping_related_to_an_offense",
+      "description": "Retrieves the MITRE mapping details associated with a QRadar offense from the QRadar server, based on the specified Offense ID.",
+      "category": "investigation",
+      "is_config_required": true,
+      "visible": true,
       "enabled": true,
       "parameters": [
         {
-          "title": "Filter String",
-          "description": "Specify the filter string based on which to retrieve the list of offenses from QRadar. For example, assigned_to=\"admin\".",
-          "required": true,
-          "editable": true,
-          "visible": true,
+          "name": "offense_id",
+          "title": "QRadar Offense ID",
           "type": "text",
-          "name": "filter_string",
-          "value": "status=\"OPEN\"",
-          "tooltip": "Specify the filter string based on which to retrieve the list of offenses from QRadar. For example, assigned_to=\"admin\"."
-        },
-        {
-          "title": "Created After",
-          "description": "Select the date and time using which to filter the result set to only include items that have been created after the specified timestamp.",
-          "required": true,
           "editable": true,
           "visible": true,
-          "type": "datetime",
-          "name": "start_time",
-          "tooltip": "Select the date and time using which to filter the result set to only include items that have been created after the specified timestamp."
+          "required": true,
+          "tooltip": "Specify the QRadar Offense ID to retrieve the associated MITRE ATT\u0026CK mapping.",
+          "description": "Specify the Offense ID based on which you want to retrieve mitre mapping from QRadar.",
+          "isOnChange": false,
+          "onchange": {}
+        }
+      ],
+      "output_schema": [
+        {
+          "rule_name": "",
+          "id": "",
+          "override_id": "",
+          "has_ibm_default": "",
+          "last_updated": "",
+          "min_mitre_version": "",
+          "mapping": [
+            {
+              "tactic_id": "",
+              "tactic_name": "",
+              "confidence": "",
+              "user_override": "",
+              "enabled": "",
+              "ibm_default": "",
+              "techniques": [
+                {
+                  "technique_id": "",
+                  "technique_name": "",
+                  "confidence": "",
+                  "enabled": ""
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/qradar/playbooks/playbooks.json
+++ b/qradar/playbooks/playbooks.json
@@ -2,1872 +2,42 @@
   "type": "workflow_collections",
   "data": [
     {
-      "@context": "/api/3/contexts/WorkflowCollection",
+      "uuid": "fcec4c33-b791-4e17-919f-e8657549c3d6",
       "@type": "WorkflowCollection",
-      "name": "Sample - IBM QRadar - 1.6.2",
-      "description": "Sample playbooks for \"IBM QRadar\" connector. If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.",
+      "name": "Sample - IBM QRadar - 1.6.3",
+      "description": "IBM QRadar is an enterprise security information and event management (SIEM) product. Fortinet FortiSOAR connector for IBM QRadar allows users to invoke QRadar API, perform Ariel Queries and operations like Get Offense,related events,update and close offenses.",
       "visible": true,
-      "image": "/api/3/images/85fe3409-e896-4e8e-9663-5cf02e8e15bd",
-      "id": 276,
-      "createDate": 1676990202.918178,
-      "modifyDate": 1676990202.918178,
-      "deletedAt": null,
-      "importedBy": [],
+      "image": null,
       "recordTags": [
         "qradar"
       ],
       "workflows": [
         {
           "@type": "Workflow",
+          "uuid": "afb7ca2a-fc2b-4b05-a231-da5d11097e75",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
           "triggerLimit": null,
-          "name": "Get Events Related to an Offense",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves details of events associated with a QRadar offense, from the QRadar server, based on the QRadar offense ID that you have specified.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/b19ad1a6-6e58-4b54-b65a-21329bdcaf8c",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Events Related to an Offense",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "offense_id": "",
-                  "start_time": "",
-                  "max_results": 100,
-                  "last_updated_time": ""
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_events_related_to_offense",
-                "operationTitle": "Get Events Related to an Offense",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "6eb5ccca-338e-44e3-b0db-6b3ec693d139"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "241ca2d2-8087-438b-8578-4d2e67af9701",
-                "title": "IBM QRadar: Get Events Related to an Offense",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "b19ad1a6-6e58-4b54-b65a-21329bdcaf8c"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Events Related to an Offense",
-              "targetStep": "/api/3/workflow_steps/6eb5ccca-338e-44e3-b0db-6b3ec693d139",
-              "sourceStep": "/api/3/workflow_steps/b19ad1a6-6e58-4b54-b65a-21329bdcaf8c",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "9b2d49b1-ba86-4ec7-b38f-394e43cc15ff"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "0ca36969-5478-44ba-858a-0a1eb71d6928",
-          "id": 4074,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Offense Closing Reasons",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves a list of closing reasons associated with all offenses from the QRadar server.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/b8f856d1-a2fc-4bda-9361-76b78f71485f",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "03e1edd8-4e46-43b6-954c-f7e2b4c8d91f",
-                "title": "IBM QRadar: Get Offense Closing Reasons",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "b8f856d1-a2fc-4bda-9361-76b78f71485f"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Offense Closing Reasons",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": [],
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_closing_reasons",
-                "operationTitle": "Get Offense Closing Reasons",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "e252f0f6-397e-45fe-8125-b9e68634a298"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Offense Closing Reasons",
-              "targetStep": "/api/3/workflow_steps/e252f0f6-397e-45fe-8125-b9e68634a298",
-              "sourceStep": "/api/3/workflow_steps/b8f856d1-a2fc-4bda-9361-76b78f71485f",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "0f7c3999-a6ee-465b-9e23-59ab1cf12140"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "14b71a0c-b450-4447-9fab-1fe879369650",
-          "id": 4069,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Cases",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves a detailed list of cases from Qradar based on input parameters specified",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/e4b639dd-b1a6-4842-876c-28499cdd2a8e",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Cases",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "max_results": 100,
-                  "query.fields": "",
-                  "filter_string": ""
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_cases",
-                "operationTitle": "Get Cases",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "87f7c731-b2e0-43f9-a71e-bc78024d82ff"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "3b37f0fb-8f63-40ff-a774-646a28ede831",
-                "title": "IBM QRadar: Get Cases",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "e4b639dd-b1a6-4842-876c-28499cdd2a8e"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Cases",
-              "targetStep": "/api/3/workflow_steps/87f7c731-b2e0-43f9-a71e-bc78024d82ff",
-              "sourceStep": "/api/3/workflow_steps/e4b639dd-b1a6-4842-876c-28499cdd2a8e",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "c62238bc-7134-4104-953a-c4d9869722b4"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "179ae2d3-0ddf-4949-8efe-aa3154ec8ac6",
-          "id": 4082,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Source IP Addresses",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves IP address details associated with a source address IDs from the QRadar server, based on the source address IDs that you have specified",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/d280ec68-3759-432a-aad6-d3b2f73f446d",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Source IP Addresses",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": [],
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_source_ip",
-                "operationTitle": "Get Source IP Addresses",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "394c81cd-9f36-4b4b-a916-39bcc7bcd9bb"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "d3b648b1-b215-4eb7-813f-27e32a30c350",
-                "title": "IBM QRadar: Get Source IP Addresses",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "d280ec68-3759-432a-aad6-d3b2f73f446d"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Source IP Addresses",
-              "targetStep": "/api/3/workflow_steps/394c81cd-9f36-4b4b-a916-39bcc7bcd9bb",
-              "sourceStep": "/api/3/workflow_steps/d280ec68-3759-432a-aad6-d3b2f73f446d",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "c8c88b25-caf3-415e-8de9-2bcda24090c1"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "1af0ccf0-c391-43d2-907d-d58eb8a65ca6",
-          "id": 4075,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Add or Update Table Element",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Specify the element to add or update in the reference table on Qradar based on the input parameters specified.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/6b229fc2-e14c-47b8-a6df-40f756aba313",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Add or Update Table Element",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "path.name": "",
-                  "query.value": "",
-                  "query.fields": "",
-                  "query.source": "FortiSOAR",
-                  "query.domain_id": "",
-                  "query.inner_key": "",
-                  "query.namespace": "",
-                  "query.outer_key": ""
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "add_table_element",
-                "operationTitle": "Add or Update Table Element",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "21eb603f-462c-4a47-bbef-c579e4db27e3"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "66fa6703-3143-48bc-bd7e-2d96d7953404",
-                "title": "IBM QRadar: Add or Update Table Element",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "6b229fc2-e14c-47b8-a6df-40f756aba313"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Add or Update Table Element",
-              "targetStep": "/api/3/workflow_steps/21eb603f-462c-4a47-bbef-c579e4db27e3",
-              "sourceStep": "/api/3/workflow_steps/6b229fc2-e14c-47b8-a6df-40f756aba313",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "8548de23-4968-4df5-b589-6732c0a09217"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "1c523586-2b73-4901-bc1b-efbce021ac21",
-          "id": 4087,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Reference Tables",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves a detailed list of reference tables from Qradar",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/8deb5084-0a5a-44a0-a3ee-8e3394585f96",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "708c8b1e-6279-4fd9-bb41-a289546c2ae7",
-                "title": "IBM QRadar: Get Reference Tables",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "8deb5084-0a5a-44a0-a3ee-8e3394585f96"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Reference Tables",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "max_results": 100,
-                  "query.fields": "",
-                  "filter_string": ""
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_reference_tables",
-                "operationTitle": "Get Reference Tables",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "aa2f1b4e-ad4e-41ab-bf27-3e47439f7d86"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Reference Tables",
-              "targetStep": "/api/3/workflow_steps/aa2f1b4e-ad4e-41ab-bf27-3e47439f7d86",
-              "sourceStep": "/api/3/workflow_steps/8deb5084-0a5a-44a0-a3ee-8e3394585f96",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "c2e39dcf-4d35-4436-a120-7dc8b3629ff3"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "2aebb790-ba89-4a7b-be94-df4f398bddb9",
-          "id": 4084,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "IBM QRadar > Post Create Alert > Fetch Events",
-          "aliasName": null,
-          "tag": "#qradar #dataingestion",
-          "description": "Fetch events, source and destination ip address of an offense.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [
-            "qradar_timezone",
-            "qradar_event_limit",
-            "alertRecord"
-          ],
-          "synchronous": false,
-          "lastModifyDate": 1676990399,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/bd58c9c5-3e44-4760-a8a1-823162b6cb60",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Set Source Data",
-              "description": null,
-              "arguments": {
-                "alertSourceData": "{{vars.input.params.alertRecord.sourcedata | from_json}}"
-              },
-              "status": null,
-              "top": "111",
-              "left": "189",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "01ac69ff-59a2-4696-a249-a1986f582536"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Update Alert",
-              "description": null,
-              "arguments": {
-                "resource": {
-                  "sourcedata": "{{vars.offense_details | toJSON }}"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "{{vars.input.params.alertRecord['@id']}}",
-                "__recommend": [],
-                "collectionType": "/api/3/alerts",
-                "fieldOperation": {
-                  "recordTags": "Append"
-                },
-                "step_variables": []
-              },
-              "status": null,
-              "top": "353",
-              "left": "840",
-              "stepType": "/api/3/workflow_step_types/b593663d-7d13-40ce-a3a3-96dece928722",
-              "group": null,
-              "uuid": "0a5d9a2b-f044-4d65-9f28-4e21fb136aba"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Fetch Events For an Offense",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "search_string": "SELECT  {{vars.event_query_params}} FROM EVENTS WHERE INOFFENSE({{vars.alertSourceData.offense_data['id']}}) ORDER BY starttime DESC LIMIT {{vars.event_record_limit}} START  '{{vars.offense_start_time}}' STOP '{{vars.current_time}}'"
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "query_qradar",
-                "operationTitle": "Make an Ariel Query to QRadar",
-                "step_variables": {
-                  "offense_details": "{\n\"offense_data\": {{vars.alertSourceData.offense_data}},\n\"events_data\": {{vars.result.data.events}}\n}"
-                }
-              },
-              "status": null,
-              "top": "271",
-              "left": "649",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "86b78a10-8246-43d9-8cce-58ef6f35ecca"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "step_variables": {
-                  "input": {
-                    "params": []
-                  }
-                }
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "group": null,
-              "uuid": "bd58c9c5-3e44-4760-a8a1-823162b6cb60"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Configuration",
-              "description": null,
-              "arguments": {
-                "current_time": "{{arrow.now(vars.input.params['qradar_timezone']).format('YYYY-MM-DD HH:mm:ss')}}",
-                "event_query_params": "starttime,sourceip,destinationip,username,QIDNAME(qid) as 'Event_Name',CATEGORYNAME(category) AS 'Category_Name',LOGSOURCENAME(logsourceid) as 'Log_Source'",
-                "event_record_limit": "{% if vars.input.params['qradar_event_limit']%}{{vars.input.params['qradar_event_limit']}}{% else %}50{% endif %}",
-                "offense_start_time": "{{arrow.get((vars.alertSourceData.offense_data.start_time | int )/1000).to(vars.input.params['qradar_timezone']).format('YYYY-MM-DD HH:mm:ss')}}"
-              },
-              "status": null,
-              "top": "200",
-              "left": "340",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "d9e3f2fd-cccd-41d1-ae45-5fbb5d1e3445"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Set Source Data",
-              "targetStep": "/api/3/workflow_steps/01ac69ff-59a2-4696-a249-a1986f582536",
-              "sourceStep": "/api/3/workflow_steps/bd58c9c5-3e44-4760-a8a1-823162b6cb60",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "687035b4-edb9-4696-9b7f-86cc2e36644d"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Set Source Data -> Configuration",
-              "targetStep": "/api/3/workflow_steps/d9e3f2fd-cccd-41d1-ae45-5fbb5d1e3445",
-              "sourceStep": "/api/3/workflow_steps/01ac69ff-59a2-4696-a249-a1986f582536",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "7e20706e-c8a7-44ea-a2cd-9955d4c6d8d5"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Fetch Events For an Offense -> Update Alert",
-              "targetStep": "/api/3/workflow_steps/0a5d9a2b-f044-4d65-9f28-4e21fb136aba",
-              "sourceStep": "/api/3/workflow_steps/86b78a10-8246-43d9-8cce-58ef6f35ecca",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "d7576874-e782-463a-9c9a-2540adc0462c"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Configuration -> Fetch Events For an Offense",
-              "targetStep": "/api/3/workflow_steps/86b78a10-8246-43d9-8cce-58ef6f35ecca",
-              "sourceStep": "/api/3/workflow_steps/d9e3f2fd-cccd-41d1-ae45-5fbb5d1e3445",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "e2315370-2548-422e-b589-43a56c2b093d"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "3464515e-56cf-4fd2-afa1-985b02064a88",
-          "id": 4094,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "dataingestion",
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "IBM QRadar > Ingest",
-          "aliasName": null,
-          "tag": "#qradar #ingest #dataingestion",
-          "description": "This playbook demonstrates Get Offense Operation.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1676990399,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/58077823-18f4-443d-8572-d65cefac5b16",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Create Alert",
-              "description": null,
-              "arguments": {
-                "when": "{{( vars.steps.Fetch_Offenses.data!= None) and ( vars.steps.Fetch_Offenses.data| length > 0)}}",
-                "for_each": {
-                  "item": "{{ vars.steps.Fetch_Offenses.data}}",
-                  "parallel": false,
-                  "condition": ""
-                },
-                "arguments": {
-                  "sourcedata": "{{vars.item}}",
-                  "qradar_pull_time": "{{vars.qradar_pull_time}}"
-                },
-                "apply_async": false,
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/5204679f-b509-4d54-8fde-1aa35030c7df"
-              },
-              "status": null,
-              "top": "360",
-              "left": "700",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "group": null,
-              "uuid": "30505af9-ece5-4d83-b610-ae2119e619af"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Update Last Offense Pull Time",
-              "description": null,
-              "arguments": {
-                "name": "Utilities",
-                "params": {
-                  "macro": "{{vars.qradar_pull_time}}",
-                  "value": "{{ vars.steps.Fetch_Offenses.curr_timestamp}}"
-                },
-                "version": "3.2.1",
-                "connector": "cyops_utilities",
-                "operation": "updatemacro",
-                "operationTitle": "CyOPs: Update Macro",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "440",
-              "left": "1020",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "40a0d1ae-1284-4108-b008-a0dedd2824b9"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "87506909-3e14-4c00-aa4c-1a1c5af24131",
-                "title": "QRadar > Fetch Offenses Now",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records}}"
-                  }
-                },
-                "displayConditions": {
-                  "alerts": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  },
-                  "incidents": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": []
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "40",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "58077823-18f4-443d-8572-d65cefac5b16"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Fetch Offenses",
-              "description": null,
-              "arguments": {
-                "arguments": [],
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/8f7eb129-98d4-43e8-a10b-8970e39065e9"
-              },
-              "status": null,
-              "top": "140",
-              "left": "240",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "group": null,
-              "uuid": "5f0e0127-a444-4b2d-8fec-c66d9845508c"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Configuration",
-              "description": null,
-              "arguments": {
-                "qradar_timezone": "{{vars.steps.Fetch_Offenses.QRadarTimeZoneMacro}}",
-                "qradar_pull_time": "{{vars.steps.Fetch_Offenses.QRadarPullTimeMacro}}",
-                "qradar_event_limit": "{{vars.steps.Fetch_Offenses.QRadarLimitMacro}}"
-              },
-              "status": null,
-              "top": "260",
-              "left": "400",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "8b0a476b-4941-40ff-b689-294fcf432d58"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Fetch Related Events of Offense",
-              "description": null,
-              "arguments": {
-                "when": "{{vars.steps.Create_Alert}}",
-                "for_each": {
-                  "item": "{{vars.steps.Create_Alert}}",
-                  "parallel": false,
-                  "condition": ""
-                },
-                "arguments": {
-                  "alertRecord": "{{vars.item}}",
-                  "qradar_timezone": "{{vars.qradar_timezone}}",
-                  "qradar_event_limit": "{{vars.qradar_event_limit}}"
-                },
-                "apply_async": true,
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/3464515e-56cf-4fd2-afa1-985b02064a88"
-              },
-              "status": null,
-              "top": "520",
-              "left": "1340",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "group": null,
-              "uuid": "a0d61337-8a53-424b-911e-ab34f062f107"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Create Alert -> Update Last Offense Pull Time",
-              "targetStep": "/api/3/workflow_steps/40a0d1ae-1284-4108-b008-a0dedd2824b9",
-              "sourceStep": "/api/3/workflow_steps/30505af9-ece5-4d83-b610-ae2119e619af",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "00c43973-04bf-4d40-a1f4-ab6308a4b827"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Update Last Offense Pull Time -> Fetch Related Events of Offense",
-              "targetStep": "/api/3/workflow_steps/a0d61337-8a53-424b-911e-ab34f062f107",
-              "sourceStep": "/api/3/workflow_steps/40a0d1ae-1284-4108-b008-a0dedd2824b9",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "1da9b1fb-5d04-43cd-a86f-a6c27b1df5b1"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Fetch Offenses",
-              "targetStep": "/api/3/workflow_steps/5f0e0127-a444-4b2d-8fec-c66d9845508c",
-              "sourceStep": "/api/3/workflow_steps/58077823-18f4-443d-8572-d65cefac5b16",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "253b9450-0f2e-4b47-b6f2-8d6c66a22518"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Fetch Offenses -> Configuration",
-              "targetStep": "/api/3/workflow_steps/8b0a476b-4941-40ff-b689-294fcf432d58",
-              "sourceStep": "/api/3/workflow_steps/5f0e0127-a444-4b2d-8fec-c66d9845508c",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "428fc692-624f-4c24-8083-4c36aeb67145"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Configuration -> Create Alert",
-              "targetStep": "/api/3/workflow_steps/30505af9-ece5-4d83-b610-ae2119e619af",
-              "sourceStep": "/api/3/workflow_steps/8b0a476b-4941-40ff-b689-294fcf432d58",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "731966c9-a634-42df-8a09-62d338d6e210"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "3567cd0f-6c2d-4319-97ad-bd9d2d63bd12",
-          "id": 4093,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "dataingestion",
-            "ingest",
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Offense Notes",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves a list of notes associated with a specified offense in QRadar based on the offense ID you have specified.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/d63a7afa-b379-48df-b0a4-281ad11d6ecf",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Offense Notes",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "offense_id": null
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_notes",
-                "operationTitle": "Get Offense Notes",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "8447f134-6710-422c-b9f0-2ed7e90fec39"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "77e68482-647b-46e3-805c-41629d61c223",
-                "title": "IBM QRadar: Get Offense Notes",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "d63a7afa-b379-48df-b0a4-281ad11d6ecf"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Offense Notes",
-              "targetStep": "/api/3/workflow_steps/8447f134-6710-422c-b9f0-2ed7e90fec39",
-              "sourceStep": "/api/3/workflow_steps/d63a7afa-b379-48df-b0a4-281ad11d6ecf",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "6e9e549d-c0b7-43c9-8782-2fa9284390f0"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "365d9550-e85c-4daa-aa15-c09142366c55",
-          "id": 4071,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Close Offense",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Closes an offense on the QRadar server based on the offense ID that you have specified.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/fba75498-a1f3-496d-a7d9-1d10d02e01bd",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Close Offense",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "offense_id": null,
-                  "closure_note": null,
-                  "offense_close_id": null
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "close_offense",
-                "operationTitle": "Close Offense",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "9a04f729-dad7-4754-b612-1dff8a6e71f2"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "e7e4a469-5de5-489d-a708-15a9d5162085",
-                "title": "IBM QRadar: Close Offense",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "fba75498-a1f3-496d-a7d9-1d10d02e01bd"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Close Offense",
-              "targetStep": "/api/3/workflow_steps/9a04f729-dad7-4754-b612-1dff8a6e71f2",
-              "sourceStep": "/api/3/workflow_steps/fba75498-a1f3-496d-a7d9-1d10d02e01bd",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "c6b89d70-db96-483a-a712-22380c9aac60"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "4328bd09-4468-4e78-a243-89f7046093f5",
-          "id": 4072,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Create Note",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Creates a note for a specified offense in QRadar based on the offense ID you have specified.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/abaa8ae9-64fe-42ec-be47-b3ae8060919a",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Create Note",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "offense_id": null,
-                  "closure_note": null
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "add_notes",
-                "operationTitle": "Create Note",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "574df82d-f135-4b9a-9ec1-c6d92a899642"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "d6e6293f-e776-40fa-9bf3-51b4da4afb55",
-                "title": "IBM QRadar: Create Note",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "abaa8ae9-64fe-42ec-be47-b3ae8060919a"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Create Note",
-              "targetStep": "/api/3/workflow_steps/574df82d-f135-4b9a-9ec1-c6d92a899642",
-              "sourceStep": "/api/3/workflow_steps/abaa8ae9-64fe-42ec-be47-b3ae8060919a",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "7ba8cd28-11b1-438c-b3f8-8b1a6a578d01"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "4f38cbf2-482e-477f-98a7-9a7c65180653",
-          "id": 4073,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "> IBM QRadar > Create Alert",
-          "aliasName": null,
-          "tag": "#qradar #dataingestion #create",
-          "description": "This playbook creates the offense as an alert in CyOPs.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [
-            "sourcedata",
-            "qradar_pull_time"
-          ],
-          "synchronous": false,
-          "lastModifyDate": 1676990399,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/cd2b3031-5844-43bc-9152-07a502551c98",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Add a note of offense update",
-              "description": null,
-              "arguments": {
-                "when": "{{vars.sourcedata.start_time > ((vars.input.params['qradar_pull_time']| int)*1000) or vars.sourcedata.last_updated_time > ((vars.input.params['qradar_pull_time']| int)*1000)}}",
-                "resource": {
-                  "type": "/api/3/picklists/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                  "people": [],
-                  "content": "<p>Below is the latest summary:</p>\n<p>status: {{vars.sourcedata.status}}<br />inactive: {{vars.sourcedata.inactive}}<br />severity: {{vars.sourcedata.severity}}<br />magnitude: {{vars.sourcedata.magnitude}}<br />relevance: {{vars.sourcedata.relevance}}<br />categories: {{vars.sourcedata.categories}}<br />assigned_to: {{vars.sourcedata.assigned_to}}<br />event_count: {{vars.sourcedata.event_count}}<br />closing_user: {{vars.sourcedata.closing_user}}<br />offense_type: {{vars.sourcedata.offense_type}}</p>",
-                  "__replace": "",
-                  "isImportant": false,
-                  "peopleUpdated": false
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "/api/3/comments",
-                "__recommend": [],
-                "fieldOperation": {
-                  "recordTags": "Overwrite"
-                },
-                "step_variables": []
-              },
-              "status": null,
-              "top": "200",
-              "left": "380",
-              "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
-              "group": null,
-              "uuid": "990dfc1b-980b-4bc6-9dcd-6072e938b7c1"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Create Record",
-              "description": null,
-              "arguments": {
-                "resource": {
-                  "name": "{{vars.sourcedata['description']}}",
-                  "type": "/api/3/picklists/574a6ee2-7265-4701-815e-cff83b053bce",
-                  "state": "/api/3/picklists/a1bac09b-1441-45aa-ad1b-c88744e48e72",
-                  "source": "QRadar",
-                  "status": "{{ vars.sourcedata[\"status\"]  | resolveRange(vars.alerts_status_map)}}",
-                  "comments": "[\"{{vars.steps.Add_a_note_of_offense_update['@id']}}\"]",
-                  "severity": "{{ vars.sourcedata[\"severity\"]  | resolveRange(vars.alerts_severity_map)}}",
-                  "sourceId": "{{vars.sourcedata['id']}}",
-                  "__replace": "true",
-                  "sourcedata": "{{vars.offense_data | toJSON }}",
-                  "description": "<p>{% if vars.sourcedata.source_address_details | length !=0 %}</p>\n<p>{{ vars.sourcedata.source_address_details | json2html }}</p>\n<p>{% endif %}{% if vars.sourcedata.destination_address_details | length != 0 %}</p>\n<p>{{ vars.sourcedata.destination_address_details | json2html }}</p>\n<p>{% endif %}</p>",
-                  "ackSlaStatus": "/api/3/picklists/72979f64-e8b9-4888-a965-957e0ec24818",
-                  "respSlaStatus": "/api/3/picklists/72979f64-e8b9-4888-a965-957e0ec24818",
-                  "priorityWeight": 1,
-                  "escalatedtoincident": "/api/3/picklists/2128a09c-153d-4db3-985d-de6be33deae5",
-                  "alertRemainingAckSLA": 0
-                },
-                "_showJson": false,
-                "is_upsert": true,
-                "operation": "Overwrite",
-                "collection": "/api/3/upsert/alerts",
-                "__recommend": [],
-                "fieldOperation": {
-                  "recordTags": "Overwrite"
-                },
-                "step_variables": []
-              },
-              "status": null,
-              "top": "320",
-              "left": "560",
-              "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
-              "group": null,
-              "uuid": "c56a521e-e607-4832-b766-6677c94b41a1"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "step_variables": {
-                  "input": {
-                    "params": {
-                      "sourcedata": "{{ vars.sourcedata }}",
-                      "qradar_pull_time": "{{ vars.qradar_pull_time }}"
-                    }
-                  }
-                }
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "group": null,
-              "uuid": "cd2b3031-5844-43bc-9152-07a502551c98"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Configuration",
-              "description": null,
-              "arguments": {
-                "offense_data": "{ 'offense_data':  {{vars.input.params.sourcedata}},\n'events_data': []\n}",
-                "alerts_status_map": "{'OPEN': {{'AlertStatus'| picklist('Open') }}, 'CLOSED': {{'AlertStatus'| picklist('Closed') }}}",
-                "alerts_severity_map": "{'1,2': {{'Severity'| picklist('Minimal') }}, '3,4': {{'Severity'| picklist('Low') }}, '5,6': {{'Severity'| picklist('Medium') }}, '7,8': {{'Severity'| picklist('High') }}, '9,10': {{'Severity'| picklist('Critical') }}}"
-              },
-              "status": null,
-              "top": "100",
-              "left": "220",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "fc9992c3-bfff-4b84-8143-9ac6a6f0d911"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Configuration -> Add a note of offense update",
-              "targetStep": "/api/3/workflow_steps/990dfc1b-980b-4bc6-9dcd-6072e938b7c1",
-              "sourceStep": "/api/3/workflow_steps/fc9992c3-bfff-4b84-8143-9ac6a6f0d911",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "29911627-3977-427a-8abd-80988bcbdb24"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Add a note of offense update -> Create Record",
-              "targetStep": "/api/3/workflow_steps/c56a521e-e607-4832-b766-6677c94b41a1",
-              "sourceStep": "/api/3/workflow_steps/990dfc1b-980b-4bc6-9dcd-6072e938b7c1",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "c99c15d9-61fb-4e4d-b57b-bf4ec507b669"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Configuration",
-              "targetStep": "/api/3/workflow_steps/fc9992c3-bfff-4b84-8143-9ac6a6f0d911",
-              "sourceStep": "/api/3/workflow_steps/cd2b3031-5844-43bc-9152-07a502551c98",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "e09081b8-4a45-4074-b2a5-6435c1f753a0"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "5204679f-b509-4d54-8fde-1aa35030c7df",
-          "id": 4092,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "dataingestion",
-            "create",
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Table Elements",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves the record details of a reference table defined by name from Qradar",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/65658b2d-c1be-4c2e-8d41-80b15795ba91",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Table Elements",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "path.name": "",
-                  "max_results": 100,
-                  "query.fields": "",
-                  "query.namespace": ""
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_table_elements",
-                "operationTitle": "Get Table Elements",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "0451ed2d-5e05-406b-99b4-842055f1044a"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "4ad5a7d8-42a0-4da5-800e-f532a3a9e36f",
-                "title": "IBM QRadar: Get Table Elements",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "65658b2d-c1be-4c2e-8d41-80b15795ba91"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Table Elements",
-              "targetStep": "/api/3/workflow_steps/0451ed2d-5e05-406b-99b4-842055f1044a",
-              "sourceStep": "/api/3/workflow_steps/65658b2d-c1be-4c2e-8d41-80b15795ba91",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "4f4673ed-e423-41e8-86c8-24d3a55b44af"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "55f4272c-fb4d-443c-acec-7171ed950cfd",
-          "id": 4086,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Create Case",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Create a new case on Qradar",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/a60b6bbf-427a-4581-81c2-a31cf4359a6e",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "a1ed61ea-b0e6-4b7f-a344-a92a6bab7e89",
-                "title": "IBM QRadar: Create Case",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "a60b6bbf-427a-4581-81c2-a31cf4359a6e"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Create Case",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "body.case": {
-                    "name": "case1",
-                    "assigned_to": [
-                      "admin"
-                    ]
-                  },
-                  "content_type": "application/json"
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "create_case",
-                "operationTitle": "Create Case",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "c0b6a34e-069f-49e0-850f-16f972f996b2"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Create Case",
-              "targetStep": "/api/3/workflow_steps/c0b6a34e-069f-49e0-850f-16f972f996b2",
-              "sourceStep": "/api/3/workflow_steps/a60b6bbf-427a-4581-81c2-a31cf4359a6e",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "b21f367c-3571-470b-b8d3-2efb2159b46f"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "564a3dd4-5c03-448c-807c-d4fa4df25952",
-          "id": 4083,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Invoke QRadar REST API",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Invokes a function to Get or Post an API endpoint on the QRadar server.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/04ed772d-9c25-4b59-8af8-cfc1224a8565",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "cb9b80b3-f87e-4cd4-892a-79cce5d4d2fb",
-                "title": "IBM QRadar: Invoke QRadar REST API",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "04ed772d-9c25-4b59-8af8-cfc1224a8565"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Invoke QRadar REST API",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "method": "GET"
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "invoke_api",
-                "operationTitle": "Invoke QRadar REST API",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "813ee6f9-7195-46ec-8a2f-0966e7b75c0f"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Invoke QRadar REST API",
-              "targetStep": "/api/3/workflow_steps/813ee6f9-7195-46ec-8a2f-0966e7b75c0f",
-              "sourceStep": "/api/3/workflow_steps/04ed772d-9c25-4b59-8af8-cfc1224a8565",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "5b963fb8-e57b-432c-95fa-80f34a3bd6e2"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "6ccaca55-f08f-4f7f-9f82-a80bb1df81fa",
-          "id": 4077,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Update Asset",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Updates the attributes of a specific asset on the Qradar server based on the asset ID that you have specified.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/14644e3a-19ea-4f65-b367-ae02d8ad98c5",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "6f6a2904-5058-4850-9dbe-7e2c23b1265f",
-                "title": "IBM QRadar: Update Asset",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "14644e3a-19ea-4f65-b367-ae02d8ad98c5"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Update Asset",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "body.asset": {
-                    "properties": [
-                      {
-                        "value": "testing",
-                        "type_id": 1011
-                      }
-                    ]
-                  },
-                  "content_type": "text/plain",
-                  "path.asset_id": ""
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "update_asset",
-                "operationTitle": "Update Asset",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "eb846d29-676d-423f-933e-68c99cbc6e9d"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Update Asset",
-              "targetStep": "/api/3/workflow_steps/eb846d29-676d-423f-933e-68c99cbc6e9d",
-              "sourceStep": "/api/3/workflow_steps/14644e3a-19ea-4f65-b367-ae02d8ad98c5",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "0ee43afe-4c9a-43f0-9fcb-d858df713417"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "6d1a6d2a-9b94-44a3-96f4-ec43d2aa923a",
-          "id": 4081,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Offenses from QRadar",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
           "description": "Retrieves a list of offenses from the QRadar server based on the filter string that you have specified.",
+          "name": "Get Offenses from QRadar",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
           "isActive": false,
           "debug": false,
           "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/cfd45eaf-cfa5-4a06-ad07-cba386c52314",
+          "triggerStep": "/api/3/workflow_steps/d79845af-69e5-4d3e-84dc-ddb3bf5c4943",
           "steps": [
             {
+              "uuid": "d79845af-69e5-4d3e-84dc-ddb3bf5c4943",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
+              "status": null,
               "arguments": {
-                "route": "9b213051-a45f-4a9e-9566-77c3a85025d6",
+                "route": "7f73cf9d-3dc9-4c3b-9ba2-53f7d7b3b834",
                 "title": "IBM QRadar: Get Offenses from QRadar",
                 "resources": [
                   "alerts"
@@ -1878,28 +48,27 @@
                     "records": "{{vars.input.records[0]}}"
                   }
                 },
-                "executeButtonText": "Execute",
+                "singleRecordExecution": false,
                 "noRecordExecution": true,
-                "singleRecordExecution": false
+                "executeButtonText": "Execute"
               },
-              "status": null,
-              "top": "20",
               "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "cfd45eaf-cfa5-4a06-ad07-cba386c52314"
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
+              "uuid": "de6818c7-a9a9-4818-b3ea-71f5164b70d1",
               "@type": "WorkflowStep",
               "name": "Get Offenses from QRadar",
               "description": null,
+              "status": null,
               "arguments": {
                 "name": "IBM QRadar",
                 "config": "''",
                 "params": {
                   "filter_string": "status=\"OPEN\""
                 },
-                "version": "1.6.2",
+                "version": "1.6.3",
                 "connector": "qradar",
                 "operation": "get_offenses",
                 "operationTitle": "Get Offenses from QRadar",
@@ -1907,1362 +76,49 @@
                   "output_data": "{{vars.result}}"
                 }
               },
-              "status": null,
-              "top": "120",
               "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "f9c99172-a599-4f4f-9428-2b958e7119cf"
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
+              "uuid": "fb68977f-5918-40b9-a6d3-8ae13c82d4d6",
+              "label": null,
+              "isExecuted": false,
               "name": "Start-> Get Offenses from QRadar",
-              "targetStep": "/api/3/workflow_steps/f9c99172-a599-4f4f-9428-2b958e7119cf",
-              "sourceStep": "/api/3/workflow_steps/cfd45eaf-cfa5-4a06-ad07-cba386c52314",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "9ded33ae-77c4-467e-9a34-c6268025525d"
+              "sourceStep": "/api/3/workflow_steps/d79845af-69e5-4d3e-84dc-ddb3bf5c4943",
+              "targetStep": "/api/3/workflow_steps/de6818c7-a9a9-4818-b3ea-71f5164b70d1"
             }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "755f8abf-a15c-418a-b3d5-4195fdd17477",
-          "id": 4067,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
           ]
         },
         {
           "@type": "Workflow",
+          "uuid": "59849093-a3d8-4c5e-ada8-2ec1c0a3f4d2",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
           "triggerLimit": null,
-          "name": "Get Offense Types",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves a list containing IDs of all the offense types from the QRadar server.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/74c76bb9-e3f8-4ca0-9212-f263a06d0041",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "bc9bba85-1766-4b8a-b812-ad836b30c82b",
-                "title": "IBM QRadar: Get Offense Types",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "74c76bb9-e3f8-4ca0-9212-f263a06d0041"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Offense Types",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": [],
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_offense_type",
-                "operationTitle": "Get Offense Types",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "bcc14e4c-2be5-4189-acce-47557c949ca2"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Offense Types",
-              "targetStep": "/api/3/workflow_steps/bcc14e4c-2be5-4189-acce-47557c949ca2",
-              "sourceStep": "/api/3/workflow_steps/74c76bb9-e3f8-4ca0-9212-f263a06d0041",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "7266e778-8b77-4c5f-baa6-2fe10d67f225"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "81fcbe98-f6de-4ee5-9212-c9cd805f011c",
-          "id": 4070,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Manipulate Reference Set Content",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Adds or deletes the content that you have specified from a specified reference set on QRadar.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/33378610-bd3d-4e6f-ac06-5f2591e7608f",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Manipulate Reference Set Content",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "method": "Retrieves Value"
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "handle_reference_set_value",
-                "operationTitle": "Manipulate Reference Set Content",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "0ecbd155-30b3-418f-831c-e0355d60663c"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "c385ad0e-847c-45bd-a634-cda1f415e28c",
-                "title": "IBM QRadar: Manipulate Reference Set Content",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "33378610-bd3d-4e6f-ac06-5f2591e7608f"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Manipulate Reference Set Content",
-              "targetStep": "/api/3/workflow_steps/0ecbd155-30b3-418f-831c-e0355d60663c",
-              "sourceStep": "/api/3/workflow_steps/33378610-bd3d-4e6f-ac06-5f2591e7608f",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "50391b52-25e7-46b5-b64d-74bb89c90c3e"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "83e93e5e-1921-4e00-b30d-041c77c5a045",
-          "id": 4078,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "> IBM QRadar > Fetch",
-          "aliasName": null,
-          "tag": "#qradar #fetch #dataingestion",
-          "description": "This playbook fetches the Offenses.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": 1676990399,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/26b987c5-7518-4050-acc3-f96380405d73",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Calculate QRadar Epoch Time",
-              "description": null,
-              "arguments": {
-                "qradar_epoch": "{{ ( arrow.get(vars.curr_timestamp).shift(minutes=-vars.time_diff_min).int_timestamp) * 1000}}"
-              },
-              "status": null,
-              "top": "760",
-              "left": "680",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "14ba7403-990a-4934-856c-5a3462e316b1"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "step_variables": {
-                  "input": {
-                    "params": []
-                  },
-                  "_configuration_schema": "[{\n\t\t\"title\": \"Search Query\",\n\t\t\"tooltip\": \"The Query to be run on QRadar to fetch offenses\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"text\",\n\t\t\"name\": \"filter_string\",\n\t\t\"value\": \"status=\\\"OPEN\\\"\"\n\t}, {\n\t\t\"title\": \"Pull Offenses in the last X minutes\",\n\t\t\"tooltip\": \"Limit the search query specified above to filter the offenses created or modified in the last X minutes\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"text\",\n\t\t\"name\": \"Pull_Sample_Offense_in_Past_X_Minutes\",\n\t\t\"value\": 10\n\n\t},\n\t{\n\t\t\"title\": \"Timezone of the QRadar server\",\n\t\t\"tooltip\": \"Required for the time conversion to pull events since the last X minutes for an offense\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"text\",\n\t\t\"name\": \"qradar_timezone\",\n\t\t\"value\": \"UTC\"\n\n\t},\n\t{\n\t\t\"title\": \"Event Record Limit\",\n\t\t\"tooltip\": \"Pull number of events for an offense\",\n\t\t\"required\": true,\n\t\t\"editable\": true,\n\t\t\"visible\": true,\n\t\t\"type\": \"integer\",\n\t\t\"name\": \"event_record_limit\",\n\t\t\"value\": 50\n\t}\n]"
-                }
-              },
-              "status": null,
-              "top": "60",
-              "left": "80",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "group": null,
-              "uuid": "26b987c5-7518-4050-acc3-f96380405d73"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Collect IP ids",
-              "description": null,
-              "arguments": {
-                "src_ips": "{{ vars.steps.Get_Offenses.data | json_query('[*].source_address_ids[]') }}",
-                "destinations_ips": "{{ vars.steps.Get_Offenses.data | json_query('[*].local_destination_address_ids[]') }}"
-              },
-              "status": null,
-              "top": "980",
-              "left": "840",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "6dc195a7-92f3-411d-9579-dd7088b64d29"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Set Result",
-              "description": null,
-              "arguments": {
-                "data": "{{vars.all_offenses}}",
-                "curr_timestamp": "{{vars.curr_timestamp}}",
-                "QRadarLimitMacro": "{{vars.macro_list[2].get(\"macro_value\")}}",
-                "QRadarPullTimeMacro": "{{vars.macro_list[0].get(\"macro_name\")}}",
-                "QRadarTimeZoneMacro": "{{vars.macro_list[1].get(\"macro_value\")}}"
-              },
-              "status": null,
-              "top": "1460",
-              "left": "1040",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "8a34a1b3-d51f-4ce0-9cb1-65fd41a24a3c"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Update Offenses With IP Details",
-              "description": null,
-              "arguments": {
-                "_dummy_for_src_addrs": "{% for each_offense in vars.all_offenses %}\n {% set offense_src_ips = [] %}\n {% for each_ip in vars.steps.Get_Source_Address_Details.data %}\n {% if each_ip.id in each_offense.source_address_ids %}\n {% set _temp =  offense_src_ips.append(each_ip) %}\n {% endif %}\n{% endfor %}\n{% set _temp2 = each_offense.update({\"source_address_details\": offense_src_ips}) %}\n {% endfor %}",
-                "_dummy_for_dest_addrs": "{% for each_offense in vars.all_offenses %}\n {% set offense_dest_ips = [] %}\n {% for each_ip in vars.steps.Get_Destination_Address_Details.data %}\n {% if each_ip.id in each_offense.local_destination_address_ids %}\n {% set _temp =  offense_dest_ips.append(each_ip) %}\n{% endif %}\n{% endfor %}\n{% set _temp2 = each_offense.update({\"destination_address_details\": offense_dest_ips}) %}\n {% endfor %}"
-              },
-              "status": null,
-              "top": "1320",
-              "left": "1040",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "8d4973b1-a562-4108-b55e-3683fd078174"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Set Time Configuration",
-              "description": null,
-              "arguments": {
-                "curr_timestamp": "{{arrow.utcnow().int_timestamp}}",
-                "last_pull_time": "{% if (vars.steps.Get_Macro_Value.data[\"hydra:member\"] | length) > 0 and vars.steps.Get_Macro_Value.data[\"hydra:member\"][0].value | int  > 0 %}{{vars.steps.Get_Macro_Value.data[\"hydra:member\"][0].value}}{% else %}{{ (arrow.utcnow().int_timestamp) - (vars.Pull_Sample_Offense_in_Past_X_Minutes| int)  *60 }}{% endif %}"
-              },
-              "status": null,
-              "top": "520",
-              "left": "480",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "9386adbd-ddfb-4127-9de2-7bb57dd6a1ad"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Destination Address Details",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "when": "{{(vars.all_offenses | length > 0) and (vars.destinations_ips | length > 0)}}",
-                "config": "",
-                "params": {
-                  "destination_address_ids": "{{vars.destinations_ips}}"
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_destination_ip",
-                "operationTitle": "Get Destination IP Addresses",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "1200",
-              "left": "1040",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "968f0cd3-ffe4-4801-9c3b-3c3c75ef92b8"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Configuration",
-              "description": null,
-              "arguments": {
-                "macro_name": "{{vars['audit_info']['cyops_playbook_iri'].split('/')[-1].replace('-','_')}}",
-                "filter_string": "status=\"OPEN\"",
-                "qradar_timezone": "UTC",
-                "event_record_limit": "50",
-                "Pull_Sample_Offense_in_Past_X_Minutes": "10"
-              },
-              "status": null,
-              "top": "180",
-              "left": "80",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "9a4ba603-cd3f-4821-a459-2fd016035e7a"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Environment Setup",
-              "description": null,
-              "arguments": {
-                "when": "{{vars.request.env_setup}}",
-                "for_each": {
-                  "item": "{{vars.macro_list}}",
-                  "__bulk": false,
-                  "parallel": true,
-                  "condition": ""
-                },
-                "arguments": {
-                  "QRadarMacroName": "{{vars.item.macro_name}}",
-                  "QRadarMacroValue": "{{vars.item.macro_value}}",
-                  "overrideIfNoMatch": "{{vars.item.override}}"
-                },
-                "apply_async": false,
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/a7f82034-9e72-48b6-9d2a-3acd2043aceb"
-              },
-              "status": null,
-              "top": "280",
-              "left": "480",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "group": null,
-              "uuid": "b3fe0300-1053-45a1-a4df-447351e9497a"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Macro Value",
-              "description": null,
-              "arguments": {
-                "params": {
-                  "iri": "/api/wf/api/dynamic-variable/?name={{vars.macro_list[0].get(\"macro_name\")}}",
-                  "body": "",
-                  "method": "GET"
-                },
-                "version": "3.2.1",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "400",
-              "left": "480",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "group": null,
-              "uuid": "bb772e1f-3e5e-4b3c-82c2-41024745089a"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Create Macro List",
-              "description": null,
-              "arguments": {
-                "macro_list": "[{\"macro_name\": \"QRadarLastOffensePullTime_{{vars.macro_name}}\" , \"macro_value\": 0, \"override\": false},{\"macro_name\": \"QRadarTimeZone_{{vars.macro_name}}\" , \"macro_value\": \"{{vars.qradar_timezone}}\", \"override\": true},{\"macro_name\": \"QRadarEventLimit_{{vars.macro_name}}\" , \"macro_value\": \"{{vars.event_record_limit}}\", \"override\": true}]"
-              },
-              "status": null,
-              "top": "280",
-              "left": "80",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "bb9bbc77-b394-4b54-bd85-ce9c465051eb"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Offenses",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "filter_string": "{{vars.filter_string}} and (start_time > '{{vars.qradar_epoch}}' or last_updated_time > '{{vars.qradar_epoch}}' )"
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_offenses",
-                "operationTitle": "Get Offenses from QRadar",
-                "step_variables": {
-                  "all_offenses": "{{ vars.result.data }}"
-                }
-              },
-              "status": null,
-              "top": "860",
-              "left": "840",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "d9e84be8-d771-4ab5-b9a9-6180c3827d57"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Source Address Details",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "when": "{{(vars.all_offenses | length > 0) and (vars.src_ips | length > 0)}}",
-                "config": "",
-                "params": {
-                  "source_address_ids": "{{vars.src_ips}}"
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_source_ip",
-                "operationTitle": "Get Source IP Addresses",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "1080",
-              "left": "1040",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "e1f41be9-a63b-47d3-a0c4-cd0a39780fc4"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Calculate Diff in min",
-              "description": null,
-              "arguments": {
-                "time_diff_min": "{{ (vars.curr_timestamp - vars.last_pull_time) / 60 | round }}"
-              },
-              "status": null,
-              "top": "620",
-              "left": "680",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "e7bd8d6b-fe5a-4c8e-b956-16f8b08354ae"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Create QRadar Last Offense Pull Time Macro -> Get Macro Value",
-              "targetStep": "/api/3/workflow_steps/bb772e1f-3e5e-4b3c-82c2-41024745089a",
-              "sourceStep": "/api/3/workflow_steps/b3fe0300-1053-45a1-a4df-447351e9497a",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "1641a35a-5566-41f7-b90d-8711ec64c490"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Calculate QRadar Epoch Time -> Get Offenses",
-              "targetStep": "/api/3/workflow_steps/d9e84be8-d771-4ab5-b9a9-6180c3827d57",
-              "sourceStep": "/api/3/workflow_steps/14ba7403-990a-4934-856c-5a3462e316b1",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "165871ad-e4a9-4e73-b45a-dec4ff0fa7b7"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Offenses -> Collect IP ids",
-              "targetStep": "/api/3/workflow_steps/6dc195a7-92f3-411d-9579-dd7088b64d29",
-              "sourceStep": "/api/3/workflow_steps/d9e84be8-d771-4ab5-b9a9-6180c3827d57",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "2996ef9d-adf4-4151-af90-9af429297131"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Destination Address Details -> Update Offenses With IP Details",
-              "targetStep": "/api/3/workflow_steps/8d4973b1-a562-4108-b55e-3683fd078174",
-              "sourceStep": "/api/3/workflow_steps/968f0cd3-ffe4-4801-9c3b-3c3c75ef92b8",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "359dfc5e-5b7a-4942-9f30-5c53c710cb55"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Update Offenses With IP Details -> Set Result",
-              "targetStep": "/api/3/workflow_steps/8a34a1b3-d51f-4ce0-9cb1-65fd41a24a3c",
-              "sourceStep": "/api/3/workflow_steps/8d4973b1-a562-4108-b55e-3683fd078174",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "76444248-4489-465d-8faa-e212aa79159a"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Source IP Details -> Get Destination Address Details",
-              "targetStep": "/api/3/workflow_steps/968f0cd3-ffe4-4801-9c3b-3c3c75ef92b8",
-              "sourceStep": "/api/3/workflow_steps/e1f41be9-a63b-47d3-a0c4-cd0a39780fc4",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "7c458095-4ab6-4db7-8e53-67c57179a0cb"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Collect IP ids -> Get Source IP Details",
-              "targetStep": "/api/3/workflow_steps/e1f41be9-a63b-47d3-a0c4-cd0a39780fc4",
-              "sourceStep": "/api/3/workflow_steps/6dc195a7-92f3-411d-9579-dd7088b64d29",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "7e1827bf-6581-43ea-8121-12b5ef5b81a7"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Configuration -> Copy of Configuration",
-              "targetStep": "/api/3/workflow_steps/bb9bbc77-b394-4b54-bd85-ce9c465051eb",
-              "sourceStep": "/api/3/workflow_steps/9a4ba603-cd3f-4821-a459-2fd016035e7a",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "86a16442-8846-4a96-81be-4294fdebe2fd"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Set Time Configuration -> Calculate Diff in min",
-              "targetStep": "/api/3/workflow_steps/e7bd8d6b-fe5a-4c8e-b956-16f8b08354ae",
-              "sourceStep": "/api/3/workflow_steps/9386adbd-ddfb-4127-9de2-7bb57dd6a1ad",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "95b958a3-0b67-45d8-a159-c88afc021f2c"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get Macro Value -> Set Time Configuration",
-              "targetStep": "/api/3/workflow_steps/9386adbd-ddfb-4127-9de2-7bb57dd6a1ad",
-              "sourceStep": "/api/3/workflow_steps/bb772e1f-3e5e-4b3c-82c2-41024745089a",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "c15f5cdf-e8b5-4d7b-84b9-4566f66dabe6"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Create Macro List -> Create QRadar Last Offense Pull Time Macro",
-              "targetStep": "/api/3/workflow_steps/b3fe0300-1053-45a1-a4df-447351e9497a",
-              "sourceStep": "/api/3/workflow_steps/bb9bbc77-b394-4b54-bd85-ce9c465051eb",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "dfd7c338-9cbd-40a1-9cc3-8457df2a4786"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Configuration",
-              "targetStep": "/api/3/workflow_steps/9a4ba603-cd3f-4821-a459-2fd016035e7a",
-              "sourceStep": "/api/3/workflow_steps/26b987c5-7518-4050-acc3-f96380405d73",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "e60c08c9-3e83-4403-898f-516e7bd24850"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Calculate Diff in min -> Calculate QRadar Epoch Time",
-              "targetStep": "/api/3/workflow_steps/14ba7403-990a-4934-856c-5a3462e316b1",
-              "sourceStep": "/api/3/workflow_steps/e7bd8d6b-fe5a-4c8e-b956-16f8b08354ae",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "e7ca8166-a085-4111-b6e8-ae2c7436a207"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "8f7eb129-98d4-43e8-a10b-8970e39065e9",
-          "id": 4090,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "dataingestion",
-            "fetch",
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Assets",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves a detailed list of available assets from Qradar based on input parameters specified.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/ba21f195-8141-4697-a051-07df10e9bd77",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Assets",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "query.sort": "",
-                  "max_results": 100,
-                  "query.fields": "",
-                  "filter_string": ""
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_assets",
-                "operationTitle": "Get Assets",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "b55577fd-69da-4e87-8f38-d09be025baaa"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "3068f58b-411c-400f-b189-36bd2cf46fdc",
-                "title": "IBM QRadar: Get Assets",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "ba21f195-8141-4697-a051-07df10e9bd77"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Assets",
-              "targetStep": "/api/3/workflow_steps/b55577fd-69da-4e87-8f38-d09be025baaa",
-              "sourceStep": "/api/3/workflow_steps/ba21f195-8141-4697-a051-07df10e9bd77",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "6f328f2d-db8f-4e22-be13-ead325ff8af2"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "9d09ce74-b191-4857-9931-8ffec8d349d5",
-          "id": 4080,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Delete Table Element",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Specify the element to be deleted from a reference table on Qradar based on input parameters specified.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/40aa4b76-c2f2-488e-be06-e52ce8f439c7",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Delete Table Element",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "path.name": "",
-                  "query.value": "",
-                  "query.fields": "",
-                  "path.inner_key": "",
-                  "path.outer_key": "",
-                  "query.domain_id": "",
-                  "query.namespace": ""
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "delete_table_element",
-                "operationTitle": "Delete Table Element",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "347b3159-e3c5-45fe-8f84-d545cc97a6b3"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "777c7f58-fb33-46eb-80f8-7737128556d3",
-                "title": "IBM QRadar: Delete Table Element",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "40aa4b76-c2f2-488e-be06-e52ce8f439c7"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Delete Table Element",
-              "targetStep": "/api/3/workflow_steps/347b3159-e3c5-45fe-8f84-d545cc97a6b3",
-              "sourceStep": "/api/3/workflow_steps/40aa4b76-c2f2-488e-be06-e52ce8f439c7",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "18a7b793-2888-4aa9-8cb6-17acf42ed340"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "9dd3b45b-e18b-4195-a828-920b06a8ce52",
-          "id": 4088,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Delete or Purge Reference Table",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Delete a reference table or purge its content on Qradar based on the input parameters specified.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/7478e852-e534-4e73-93c2-f387383e3ee5",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Delete or Purge Reference Table",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "path.name": "",
-                  "query.fields": "",
-                  "query.namespace": "",
-                  "query.purge_only": "false"
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "delete_reference_table",
-                "operationTitle": "Delete or Purge Reference Table",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "17ef8e9c-3878-484b-b5ff-94473bd1526e"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "ff6cb72d-5be3-4bf0-b63e-b0b9bc028086",
-                "title": "IBM QRadar: Delete or Purge Reference Table",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "7478e852-e534-4e73-93c2-f387383e3ee5"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Delete or Purge Reference Table",
-              "targetStep": "/api/3/workflow_steps/17ef8e9c-3878-484b-b5ff-94473bd1526e",
-              "sourceStep": "/api/3/workflow_steps/7478e852-e534-4e73-93c2-f387383e3ee5",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "8ddfa8e2-40c5-4d73-9c32-1ce692ed88a7"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "a663ff62-b58e-46a5-af91-0011ff6aec31",
-          "id": 4085,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": ">> IBM QRadar > Init Macros",
-          "aliasName": null,
-          "tag": "#qradar #dataingestion",
-          "description": "This playbook creates IBM QRadar macros if not exist.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [
-            "QRadarMacroName",
-            "QRadarMacroValue",
-            "overrideIfNoMatch"
-          ],
-          "synchronous": false,
-          "lastModifyDate": 1676990399,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/ab890ee1-d7fb-4f3c-875f-a81e23adc0b0",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get QRadar Macros",
-              "description": null,
-              "arguments": {
-                "name": "Utilities",
-                "params": {
-                  "iri": "/api/wf/api/dynamic-variable/?format=json&name={{vars.QRadarMacroName}}",
-                  "body": "",
-                  "method": "GET"
-                },
-                "version": "2.5.0",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "CyOPs: Make CyOPs API Call",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "120",
-              "left": "171",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "0cc6a020-e7ca-48bf-a9cd-290bcf324fdc"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Create IBM QRadar Macro",
-              "description": null,
-              "arguments": {
-                "params": {
-                  "iri": "/api/wf/api/dynamic-variable/?format=json",
-                  "body": "{ 'name': '{{vars.QRadarMacroName}}'   , 'value': '{{vars.QRadarMacroValue}}' }",
-                  "method": "POST"
-                },
-                "version": "2.5.0",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "CyOPs: Make CyOPs API Call",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "306",
-              "left": "651",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "group": null,
-              "uuid": "720cc5ee-1086-433a-ac3c-e7a2efb2ad66"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Fetch Macro Current Value",
-              "description": null,
-              "arguments": {
-                "macroExistingRecord": "{{vars.steps.Get_QRadar_Macros.data['hydra:member'][0]}}"
-              },
-              "status": null,
-              "top": "147",
-              "left": "651",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "group": null,
-              "uuid": "a11be765-fcd6-4623-8906-45022f44be36"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "step_variables": {
-                  "input": {
-                    "params": {
-                      "QRadarMacroName": "{{ vars.QRadarMacroName }}",
-                      "QRadarMacroValue": "{{ vars.QRadarMacroValue }}",
-                      "overrideIfNoMatch": "{{ vars.overrideIfNoMatch }}"
-                    }
-                  }
-                }
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "group": null,
-              "uuid": "ab890ee1-d7fb-4f3c-875f-a81e23adc0b0"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Update Macro If Required",
-              "description": null,
-              "arguments": {
-                "when": "{{(vars.input.params.overrideIfNoMatch  == true) and (vars.macroExistingRecord.value != vars.QRadarMacroValue)}}",
-                "params": {
-                  "iri": "/api/wf/api/dynamic-variable/{{ vars.macroExistingRecord.id }}/",
-                  "body": "{ 'name': '{{vars.QRadarMacroName}}'   , 'value': '{{vars.QRadarMacroValue}}' }",
-                  "method": "PUT"
-                },
-                "version": "2.7.0",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "CyOPs: Make CyOPs API Call",
-                "step_variables": []
-              },
-              "status": null,
-              "top": "147",
-              "left": "952",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "group": null,
-              "uuid": "af23eded-2fca-4893-a55f-348c4fdccb38"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "QRadar Macro Exists",
-              "description": null,
-              "arguments": {
-                "conditions": [
-                  {
-                    "option": "Not Exist",
-                    "step_iri": "/api/3/workflow_steps/720cc5ee-1086-433a-ac3c-e7a2efb2ad66",
-                    "condition": "{{ vars.steps.Get_QRadar_Macros.data['hydra:totalItems'] == 0 }}"
-                  },
-                  {
-                    "option": "Exist",
-                    "default": true,
-                    "step_iri": "/api/3/workflow_steps/a11be765-fcd6-4623-8906-45022f44be36"
-                  }
-                ]
-              },
-              "status": null,
-              "top": "228",
-              "left": "320",
-              "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-              "group": null,
-              "uuid": "b4051f74-ca2a-49a1-af9f-e402bda1477d"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start -> Get All Macros",
-              "targetStep": "/api/3/workflow_steps/0cc6a020-e7ca-48bf-a9cd-290bcf324fdc",
-              "sourceStep": "/api/3/workflow_steps/ab890ee1-d7fb-4f3c-875f-a81e23adc0b0",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "235a7c88-7c58-4aa3-b411-80b1beb543cd"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Fetch Macro Current Value -> Update Macro If Required",
-              "targetStep": "/api/3/workflow_steps/af23eded-2fca-4893-a55f-348c4fdccb38",
-              "sourceStep": "/api/3/workflow_steps/a11be765-fcd6-4623-8906-45022f44be36",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "3529a9e7-e89b-41de-b4b5-0de35f712b8d"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Check IBM QRadar Macro -> Create IBM QRadar Macro",
-              "targetStep": "/api/3/workflow_steps/720cc5ee-1086-433a-ac3c-e7a2efb2ad66",
-              "sourceStep": "/api/3/workflow_steps/b4051f74-ca2a-49a1-af9f-e402bda1477d",
-              "label": "Not Exist",
-              "isExecuted": false,
-              "uuid": "706b41ae-34db-4753-a5e8-8b8f91f9b415"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "Get All Macros -> Check IBM QRadar Macro",
-              "targetStep": "/api/3/workflow_steps/b4051f74-ca2a-49a1-af9f-e402bda1477d",
-              "sourceStep": "/api/3/workflow_steps/0cc6a020-e7ca-48bf-a9cd-290bcf324fdc",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "93bf9e92-34cb-477c-be93-7771d380fa67"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "name": "QRadar Macro Exists -> Fetch Macro Current Value",
-              "targetStep": "/api/3/workflow_steps/a11be765-fcd6-4623-8906-45022f44be36",
-              "sourceStep": "/api/3/workflow_steps/b4051f74-ca2a-49a1-af9f-e402bda1477d",
-              "label": "Exist",
-              "isExecuted": false,
-              "uuid": "af5d49a8-a08b-4905-8313-092fbbc27874"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "a7f82034-9e72-48b6-9d2a-3acd2043aceb",
-          "id": 4089,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "dataingestion",
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Destination IP Addresses",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves IP address details associated with a destination address IDs from the QRadar server, based on the destination address IDs that you have specified",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/199382ed-afcd-4bb9-8865-fa8c28b44d85",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "4fb0870d-d2e8-413b-bcca-aeea3d16c24d",
-                "title": "IBM QRadar: Get Destination IP Addresses",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "199382ed-afcd-4bb9-8865-fa8c28b44d85"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Destination IP Addresses",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": [],
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_destination_ip",
-                "operationTitle": "Get Destination IP Addresses",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "6181b12d-ab99-4d1f-acd0-03cc5d272da0"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Destination IP Addresses",
-              "targetStep": "/api/3/workflow_steps/6181b12d-ab99-4d1f-acd0-03cc5d272da0",
-              "sourceStep": "/api/3/workflow_steps/199382ed-afcd-4bb9-8865-fa8c28b44d85",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "5b68fb1f-eccf-43c3-92e8-ab5099a912c7"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "ac6e4bd5-2273-4c79-8747-ae40c43ea26c",
-          "id": 4076,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Get Assets Properties",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
-          "description": "Retrieves a detailed list of available asset properties from Qradar that can be used with assets update operation.",
-          "isActive": false,
-          "debug": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [],
-          "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/272e7989-d471-4983-9304-8d0415cb70da",
-          "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Get Assets Properties",
-              "description": null,
-              "arguments": {
-                "name": "IBM QRadar",
-                "config": "''",
-                "params": {
-                  "max_results": 100,
-                  "query.fields": "",
-                  "filter_string": ""
-                },
-                "version": "1.6.2",
-                "connector": "qradar",
-                "operation": "get_assets_properties",
-                "operationTitle": "Get Assets Properties",
-                "step_variables": {
-                  "output_data": "{{vars.result}}"
-                }
-              },
-              "status": null,
-              "top": "120",
-              "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "1bed410d-c7b5-4b0e-9d73-140442621117"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "e34db2ff-edf9-47e1-a87f-4dae9c6d8d2b",
-                "title": "IBM QRadar: Get Assets Properties",
-                "resources": [
-                  "alerts"
-                ],
-                "inputVariables": [],
-                "step_variables": {
-                  "input": {
-                    "records": "{{vars.input.records[0]}}"
-                  }
-                },
-                "executeButtonText": "Execute",
-                "noRecordExecution": true,
-                "singleRecordExecution": false
-              },
-              "status": null,
-              "top": "20",
-              "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "272e7989-d471-4983-9304-8d0415cb70da"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "name": "Start-> Get Assets Properties",
-              "targetStep": "/api/3/workflow_steps/1bed410d-c7b5-4b0e-9d73-140442621117",
-              "sourceStep": "/api/3/workflow_steps/272e7989-d471-4983-9304-8d0415cb70da",
-              "label": null,
-              "isExecuted": false,
-              "uuid": "c1f63be5-c98e-4192-a399-ad4dcd1a2968"
-            }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "bc0da614-61dc-45e8-9a8f-ee7d87a57b6b",
-          "id": 4079,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
-          ]
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": "Make an Ariel Query to QRadar",
-          "aliasName": null,
-          "tag": "#IBM QRadar",
           "description": "Executes an Ariel query on the QRadar server. QRadar uses the Ariel Query Language (AQL) to search for offenses or events based on query parameters.",
+          "name": "Make an Ariel Query to QRadar",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
           "isActive": false,
           "debug": false,
           "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": null,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/482458fa-9575-49fe-99a4-c530d38e26c9",
+          "triggerStep": "/api/3/workflow_steps/761d997c-8d70-482f-a956-ed1027fa783d",
           "steps": [
             {
+              "uuid": "761d997c-8d70-482f-a956-ed1027fa783d",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
+              "status": null,
               "arguments": {
-                "route": "3d2ff315-ed57-40b9-b0e3-98d3422d393d",
+                "route": "63fa53de-96e3-432b-af02-8664cf96e7b2",
                 "title": "IBM QRadar: Make an Ariel Query to QRadar",
                 "resources": [
                   "alerts"
@@ -3273,28 +129,25 @@
                     "records": "{{vars.input.records[0]}}"
                   }
                 },
-                "executeButtonText": "Execute",
+                "singleRecordExecution": false,
                 "noRecordExecution": true,
-                "singleRecordExecution": false
+                "executeButtonText": "Execute"
               },
-              "status": null,
-              "top": "20",
               "left": "20",
-              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
-              "group": null,
-              "uuid": "482458fa-9575-49fe-99a4-c530d38e26c9"
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
+              "uuid": "00dff571-07f8-4f26-9fd5-a15ee5f5052e",
               "@type": "WorkflowStep",
               "name": "Make an Ariel Query to QRadar",
               "description": null,
+              "status": null,
               "arguments": {
                 "name": "IBM QRadar",
                 "config": "''",
-                "params": {
-                  "search_string": null
-                },
-                "version": "1.6.2",
+                "params": [],
+                "version": "1.6.3",
                 "connector": "qradar",
                 "operation": "query_qradar",
                 "operationTitle": "Make an Ariel Query to QRadar",
@@ -3302,128 +155,1836 @@
                   "output_data": "{{vars.result}}"
                 }
               },
-              "status": null,
-              "top": "120",
               "left": "188",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "d00ab3f3-362d-4088-b359-28d43e7fa7c5"
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Start-> Make an Ariel Query to QRadar",
-              "targetStep": "/api/3/workflow_steps/d00ab3f3-362d-4088-b359-28d43e7fa7c5",
-              "sourceStep": "/api/3/workflow_steps/482458fa-9575-49fe-99a4-c530d38e26c9",
+              "uuid": "0fb7cd18-fe30-4f8b-aa4a-ef305b1f7dbb",
               "label": null,
               "isExecuted": false,
-              "uuid": "f82321ea-3b7d-4839-8150-1b1bdb9c0952"
+              "name": "Start-> Make an Ariel Query to QRadar",
+              "sourceStep": "/api/3/workflow_steps/761d997c-8d70-482f-a956-ed1027fa783d",
+              "targetStep": "/api/3/workflow_steps/00dff571-07f8-4f26-9fd5-a15ee5f5052e"
             }
-          ],
-          "groups": [],
-          "priority": null,
-          "uuid": "d0417fc9-2df2-4474-90e9-b5302aca5b21",
-          "id": 4068,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
-          "recordTags": [
-            "qradar"
           ]
         },
         {
           "@type": "Workflow",
+          "uuid": "b5f1a33b-b650-41c8-b654-215e77db1606",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
           "triggerLimit": null,
-          "name": "API - Push Offense From QRadar",
-          "aliasName": null,
-          "tag": "#qradar app",
-          "description": "This playbook demonstrate the QRadar App. You need have QRadar CyberSponse App installed on QRadar.",
+          "description": "Retrieves a list of closing reasons associated with all offenses from the QRadar server.",
+          "name": "Get Offense Closing Reasons",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
           "isActive": false,
           "debug": false,
           "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
-          "lastModifyDate": 1676990399,
-          "collection": "/api/3/workflow_collections/9a38c491-3e1d-4840-af6e-1407a79e15ad",
-          "versions": [],
-          "triggerStep": "/api/3/workflow_steps/5cc52ab8-80ad-49b0-9dad-4987bd043068",
+          "triggerStep": "/api/3/workflow_steps/ad03f884-4198-4b77-8868-121697cc791b",
           "steps": [
             {
+              "uuid": "ad03f884-4198-4b77-8868-121697cc791b",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
-              "arguments": {
-                "route": "qradar",
-                "authentication_methods": [
-                  ""
-                ]
-              },
               "status": null,
-              "top": "53",
-              "left": "234",
-              "stepType": "/api/3/workflow_step_types/df26c7a2-4166-4ca5-91e5-548e24c01b5f",
-              "group": null,
-              "uuid": "5cc52ab8-80ad-49b0-9dad-4987bd043068"
+              "arguments": {
+                "route": "f6c0d8bf-19e5-4504-8df0-525d1a451c52",
+                "title": "IBM QRadar: Get Offense Closing Reasons",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
+              "uuid": "7722e068-6356-4e0d-a904-f658197ead43",
               "@type": "WorkflowStep",
-              "name": "Get Offense Details",
+              "name": "Get Offense Closing Reasons",
               "description": null,
+              "status": null,
               "arguments": {
                 "name": "IBM QRadar",
-                "config": "",
-                "params": {
-                  "filter_string": "id={{ vars.request.data.Offense_ID }}"
-                },
-                "version": "1.6.2",
+                "config": "''",
+                "params": [],
+                "version": "1.6.3",
                 "connector": "qradar",
-                "operation": "get_offenses",
-                "operationTitle": "Get Offenses from QRadar",
-                "step_variables": []
+                "operation": "get_closing_reasons",
+                "operationTitle": "Get Offense Closing Reasons",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
               },
-              "status": null,
-              "top": "160",
-              "left": "400",
-              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-              "group": null,
-              "uuid": "7ac14252-3ffa-421a-8074-7d0808119a96"
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "name": "Start -> Get Offense Details",
-              "targetStep": "/api/3/workflow_steps/7ac14252-3ffa-421a-8074-7d0808119a96",
-              "sourceStep": "/api/3/workflow_steps/5cc52ab8-80ad-49b0-9dad-4987bd043068",
+              "uuid": "d15b5ede-7d12-4e04-a0c1-89427b4dcc11",
               "label": null,
               "isExecuted": false,
-              "uuid": "75e2ffa5-ea71-47c6-87df-1aa7e006d911"
+              "name": "Start-> Get Offense Closing Reasons",
+              "sourceStep": "/api/3/workflow_steps/ad03f884-4198-4b77-8868-121697cc791b",
+              "targetStep": "/api/3/workflow_steps/7722e068-6356-4e0d-a904-f658197ead43"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "5d80d7d7-82b7-4510-98ac-1b1eda4f5dc1",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves a list containing IDs of all the offense types from the QRadar server.",
+          "name": "Get Offense Types",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/dd0a61b2-ffe8-4a48-a961-6620298e3676",
+          "steps": [
+            {
+              "uuid": "dd0a61b2-ffe8-4a48-a961-6620298e3676",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "0c28a5c5-4802-4d18-b534-737e7e193951",
+                "title": "IBM QRadar: Get Offense Types",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "a7b8bf4c-5b0d-45db-82b2-cdbcf086652a",
+              "@type": "WorkflowStep",
+              "name": "Get Offense Types",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": [],
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_offense_type",
+                "operationTitle": "Get Offense Types",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
             }
           ],
-          "groups": [],
-          "priority": null,
-          "uuid": "ebcdedf8-82d0-4072-a71c-badec8b2ccc8",
-          "id": 4091,
-          "owners": [],
-          "isPrivate": false,
-          "deletedAt": null,
-          "importedBy": [],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "ea1f4473-9cc4-4f45-9bcf-20f01dcad056",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Offense Types",
+              "sourceStep": "/api/3/workflow_steps/dd0a61b2-ffe8-4a48-a961-6620298e3676",
+              "targetStep": "/api/3/workflow_steps/a7b8bf4c-5b0d-45db-82b2-cdbcf086652a"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "9f67dd4a-c931-45f1-94ac-1e24aa69b9b4",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves a list of notes associated with a specified offense in QRadar based on the offense ID you have specified.",
+          "name": "Get Offense Notes",
+          "tag": "#IBM QRadar",
           "recordTags": [
-            "qradar app"
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/336e6603-d427-4e42-bd84-485e862a1d6d",
+          "steps": [
+            {
+              "uuid": "336e6603-d427-4e42-bd84-485e862a1d6d",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "4ee5ce0b-b801-4609-93a1-30dcd46d38dd",
+                "title": "IBM QRadar: Get Offense Notes",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "5c93c264-7bf9-49e8-aaaf-36b2cdaa4d4a",
+              "@type": "WorkflowStep",
+              "name": "Get Offense Notes",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": [],
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_notes",
+                "operationTitle": "Get Offense Notes",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "cf4bd84e-5ebe-4cb1-b6a9-d19d2646338d",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Offense Notes",
+              "sourceStep": "/api/3/workflow_steps/336e6603-d427-4e42-bd84-485e862a1d6d",
+              "targetStep": "/api/3/workflow_steps/5c93c264-7bf9-49e8-aaaf-36b2cdaa4d4a"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "fa6dc8c2-a89e-4261-b4e9-e73f06f5c3ad",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Closes an offense on the QRadar server based on the offense ID that you have specified.",
+          "name": "Close Offense",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/99d9bee0-9a59-4e1a-ba38-31a5dc7c2920",
+          "steps": [
+            {
+              "uuid": "99d9bee0-9a59-4e1a-ba38-31a5dc7c2920",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "867c639a-ad9c-425f-9a65-66d6b013935f",
+                "title": "IBM QRadar: Close Offense",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "630bc037-6244-4583-b3be-557e7467cfbb",
+              "@type": "WorkflowStep",
+              "name": "Close Offense",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": [],
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "close_offense",
+                "operationTitle": "Close Offense",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "f5c52544-c367-4570-afea-f1cb6d2329d2",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Close Offense",
+              "sourceStep": "/api/3/workflow_steps/99d9bee0-9a59-4e1a-ba38-31a5dc7c2920",
+              "targetStep": "/api/3/workflow_steps/630bc037-6244-4583-b3be-557e7467cfbb"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "34cc1ad1-7ff1-4406-8fef-9d76fc98b936",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Creates a note for a specified offense in QRadar based on the offense ID you have specified.",
+          "name": "Create Note",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/cc59a9c6-4b69-45bc-a2b4-c433a6060096",
+          "steps": [
+            {
+              "uuid": "cc59a9c6-4b69-45bc-a2b4-c433a6060096",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "39b5373f-1814-43fc-931c-1191600d581d",
+                "title": "IBM QRadar: Create Note",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "aca730e0-c90d-4f3d-836d-433109b5a9c5",
+              "@type": "WorkflowStep",
+              "name": "Create Note",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": [],
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "add_notes",
+                "operationTitle": "Create Note",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "eb1d9aeb-a854-4d11-8c8f-303f552bba7f",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Create Note",
+              "sourceStep": "/api/3/workflow_steps/cc59a9c6-4b69-45bc-a2b4-c433a6060096",
+              "targetStep": "/api/3/workflow_steps/aca730e0-c90d-4f3d-836d-433109b5a9c5"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "dbd3be55-c280-469f-ace0-15b6b909b897",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves details of events associated with a QRadar offense, from the QRadar server, based on the QRadar offense ID that you have specified.",
+          "name": "Get Events Related to an Offense",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/666d0b59-195a-42b6-9e4f-8e79c8613a29",
+          "steps": [
+            {
+              "uuid": "666d0b59-195a-42b6-9e4f-8e79c8613a29",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "f3e3c299-4558-4293-bbd3-44e5b4c85135",
+                "title": "IBM QRadar: Get Events Related to an Offense",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "277c9cc4-70a4-41bb-b9ab-a40258f117d6",
+              "@type": "WorkflowStep",
+              "name": "Get Events Related to an Offense",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "offense_id": "",
+                  "start_time": "",
+                  "last_updated_time": "",
+                  "max_results": 100
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_events_related_to_offense",
+                "operationTitle": "Get Events Related to an Offense",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "8c1dec69-db32-4013-ab08-f4d414ab3367",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Events Related to an Offense",
+              "sourceStep": "/api/3/workflow_steps/666d0b59-195a-42b6-9e4f-8e79c8613a29",
+              "targetStep": "/api/3/workflow_steps/277c9cc4-70a4-41bb-b9ab-a40258f117d6"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "5c455226-ed8c-4862-a518-0366b89f043f",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves IP address details associated with source address IDs from the QRadar server, based on the source address IDs that you have specified",
+          "name": "Get Source IP Addresses",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/98e9dae4-e3f0-41e8-b2ce-a8f079df38f4",
+          "steps": [
+            {
+              "uuid": "98e9dae4-e3f0-41e8-b2ce-a8f079df38f4",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "c9aec81a-3b5a-4599-837f-67617d152bbf",
+                "title": "IBM QRadar: Get Source IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "3555b620-56a5-4109-b4e8-0c8166c41f59",
+              "@type": "WorkflowStep",
+              "name": "Get Source IP Addresses",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": [],
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_source_ip",
+                "operationTitle": "Get Source IP Addresses",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "24525151-5e70-4cf1-a439-98884a453425",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Source IP Addresses",
+              "sourceStep": "/api/3/workflow_steps/98e9dae4-e3f0-41e8-b2ce-a8f079df38f4",
+              "targetStep": "/api/3/workflow_steps/3555b620-56a5-4109-b4e8-0c8166c41f59"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "24396842-f02d-4d04-91b9-54c25440bb34",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves IP address details associated with the destination address IDs from the QRadar server, based on the destination address IDs that you have specified",
+          "name": "Get Destination IP Addresses",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/bb245c83-907d-4357-a127-5264979ad8d8",
+          "steps": [
+            {
+              "uuid": "bb245c83-907d-4357-a127-5264979ad8d8",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "b4bc81d0-e4c2-4bca-b5bf-96dd283cbc3f",
+                "title": "IBM QRadar: Get Destination IP Addresses",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "d3852c39-2727-47b8-a322-28d20279472e",
+              "@type": "WorkflowStep",
+              "name": "Get Destination IP Addresses",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": [],
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_destination_ip",
+                "operationTitle": "Get Destination IP Addresses",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "92de8619-f17d-4104-b043-233101a060de",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Destination IP Addresses",
+              "sourceStep": "/api/3/workflow_steps/bb245c83-907d-4357-a127-5264979ad8d8",
+              "targetStep": "/api/3/workflow_steps/d3852c39-2727-47b8-a322-28d20279472e"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "4bbd3ddd-6f33-4b62-83cf-77f095d7c876",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Invokes a function to Get or Post an API endpoint on the QRadar server.",
+          "name": "Invoke QRadar REST API",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/f6a80c87-eadd-4072-b44b-79bf8a39f919",
+          "steps": [
+            {
+              "uuid": "f6a80c87-eadd-4072-b44b-79bf8a39f919",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "54d161bb-8778-4116-9efa-862a2c723688",
+                "title": "IBM QRadar: Invoke QRadar REST API",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "638fb491-4bb2-45bc-bc8b-757840323316",
+              "@type": "WorkflowStep",
+              "name": "Invoke QRadar REST API",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "method": "GET"
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "invoke_api",
+                "operationTitle": "Invoke QRadar REST API",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "0ee0414e-3126-4d01-b5e9-0ecc2edc5517",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Invoke QRadar REST API",
+              "sourceStep": "/api/3/workflow_steps/f6a80c87-eadd-4072-b44b-79bf8a39f919",
+              "targetStep": "/api/3/workflow_steps/638fb491-4bb2-45bc-bc8b-757840323316"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "ce4c3f21-e260-4cdf-ab1a-154d4fa42023",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Adds or deletes the content that you have specified from a reference set on QRadar.",
+          "name": "Manipulate Reference Set Content",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/3317a8dc-59bb-4f22-a723-95b3c33605bf",
+          "steps": [
+            {
+              "uuid": "3317a8dc-59bb-4f22-a723-95b3c33605bf",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "59737e72-05a3-4571-bed3-dd04b079d6cb",
+                "title": "IBM QRadar: Manipulate Reference Set Content",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "2459f1a2-c848-4b88-bb4b-63d7e186ce47",
+              "@type": "WorkflowStep",
+              "name": "Manipulate Reference Set Content",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "method": "Retrieves Value"
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "handle_reference_set_value",
+                "operationTitle": "Manipulate Reference Set Content",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "283d3ef1-6dde-44b0-a6f2-b64c258bcb4d",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Manipulate Reference Set Content",
+              "sourceStep": "/api/3/workflow_steps/3317a8dc-59bb-4f22-a723-95b3c33605bf",
+              "targetStep": "/api/3/workflow_steps/2459f1a2-c848-4b88-bb4b-63d7e186ce47"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "a5d49b52-8589-458f-8ba8-feb34f8caee3",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves a detailed list of available asset properties or specific available asset properties from QRadar based on input parameters specified.",
+          "name": "Get Assets Properties",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/58e855a9-c794-4877-9a10-2bae3a23ea4d",
+          "steps": [
+            {
+              "uuid": "58e855a9-c794-4877-9a10-2bae3a23ea4d",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "2d7bab81-a571-458c-bccf-f712f01fcc4f",
+                "title": "IBM QRadar: Get Assets Properties",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "2f2b5445-0603-4b66-9518-17d5146c2f05",
+              "@type": "WorkflowStep",
+              "name": "Get Assets Properties",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "max_results": 100,
+                  "filter_string": "",
+                  "query.fields": ""
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_assets_properties",
+                "operationTitle": "Get Assets Properties",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "277bde2e-abe8-4630-ab0b-e0ad8220bab3",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Assets Properties",
+              "sourceStep": "/api/3/workflow_steps/58e855a9-c794-4877-9a10-2bae3a23ea4d",
+              "targetStep": "/api/3/workflow_steps/2f2b5445-0603-4b66-9518-17d5146c2f05"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "2772d84a-2077-4f1d-9720-b25f871858ff",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves a detailed list of all available assets or specific available assets from QRadar based on input parameters specified.",
+          "name": "Get Assets",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/8dc6f005-d64d-438d-89e6-d3b711e7c8b4",
+          "steps": [
+            {
+              "uuid": "8dc6f005-d64d-438d-89e6-d3b711e7c8b4",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "a31d83a8-a93f-4f01-a5cd-7ffc72c4237f",
+                "title": "IBM QRadar: Get Assets",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "478bddc3-aeb0-4777-9808-230c37943dee",
+              "@type": "WorkflowStep",
+              "name": "Get Assets",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "filter_string": "",
+                  "max_results": 100,
+                  "query.fields": "",
+                  "query.sort": ""
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_assets",
+                "operationTitle": "Get Assets",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "59721a26-4b94-457b-88a7-d2473130a4ec",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Assets",
+              "sourceStep": "/api/3/workflow_steps/8dc6f005-d64d-438d-89e6-d3b711e7c8b4",
+              "targetStep": "/api/3/workflow_steps/478bddc3-aeb0-4777-9808-230c37943dee"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "0f64582e-4ce9-48c3-a970-b38bb9b6fd35",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Updates the attributes of a specific asset on the QRadar server based on the asset ID and asset properties you have specified. Note: You can retrieve the list of asset properties using the 'Get Assets Properties' operation.",
+          "name": "Update Asset",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/df0480f0-56c2-491f-9a15-c86007fd8b26",
+          "steps": [
+            {
+              "uuid": "df0480f0-56c2-491f-9a15-c86007fd8b26",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "cbb61fea-0761-4f3e-a587-868977f08dcc",
+                "title": "IBM QRadar: Update Asset",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "79985cd1-5d92-4908-890f-41773227ac20",
+              "@type": "WorkflowStep",
+              "name": "Update Asset",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "path.asset_id": "",
+                  "body.asset": {
+                    "properties": [
+                      {
+                        "type_id": 1011,
+                        "value": "testing"
+                      }
+                    ]
+                  },
+                  "content_type": "text/plain"
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "update_asset",
+                "operationTitle": "Update Asset",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "e2853349-7922-4e4c-975d-07e09faef301",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Update Asset",
+              "sourceStep": "/api/3/workflow_steps/df0480f0-56c2-491f-9a15-c86007fd8b26",
+              "targetStep": "/api/3/workflow_steps/79985cd1-5d92-4908-890f-41773227ac20"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "330893bb-c46b-4b07-9963-6312d047a337",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves a detailed list of all cases or specific cases from QRadar based on input parameters specified. Note: This action is supported on QRadar API version 7.0 and later.",
+          "name": "Get Cases",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/f585e4d8-377f-4764-b212-2daae1c8ba8d",
+          "steps": [
+            {
+              "uuid": "f585e4d8-377f-4764-b212-2daae1c8ba8d",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "24ad07e3-c97c-4b2c-b4f1-aac02993efe2",
+                "title": "IBM QRadar: Get Cases",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "b312ad5a-122c-4c34-a078-6d92100b04f4",
+              "@type": "WorkflowStep",
+              "name": "Get Cases",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "query.fields": "",
+                  "filter_string": "",
+                  "max_results": 100
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_cases",
+                "operationTitle": "Get Cases",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "1231b7a8-f597-4750-97a5-74555302b6f3",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Cases",
+              "sourceStep": "/api/3/workflow_steps/f585e4d8-377f-4764-b212-2daae1c8ba8d",
+              "targetStep": "/api/3/workflow_steps/b312ad5a-122c-4c34-a078-6d92100b04f4"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "1e5613c6-292c-4ad1-867e-a6689019e0f4",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Creates a new case on QRadar based on the case properties you have specified. Note: This action is supported on QRadar API version 7.0 and later.",
+          "name": "Create Case",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/74f9d57f-19e6-4789-9d00-29b7bceb9752",
+          "steps": [
+            {
+              "uuid": "74f9d57f-19e6-4789-9d00-29b7bceb9752",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "3f5efbb3-f546-454f-b52a-f58b660313aa",
+                "title": "IBM QRadar: Create Case",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "8a273394-97f6-40cb-8202-361a305e6651",
+              "@type": "WorkflowStep",
+              "name": "Create Case",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "body.case": {
+                    "assigned_to": [
+                      "admin"
+                    ],
+                    "name": "case1"
+                  },
+                  "content_type": "application/json"
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "create_case",
+                "operationTitle": "Create Case",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "7f2019ce-2e1b-40c1-b67f-f6d7f762d996",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Create Case",
+              "sourceStep": "/api/3/workflow_steps/74f9d57f-19e6-4789-9d00-29b7bceb9752",
+              "targetStep": "/api/3/workflow_steps/8a273394-97f6-40cb-8202-361a305e6651"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "f2e4c578-feb5-4ded-ab6e-a5d5f9f82763",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves a detailed list of all reference tables or specific reference tables from QRadar based on input parameters specified.",
+          "name": "Get Reference Tables",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/cdbfd84d-70ec-4327-a9a9-7a883b7873ed",
+          "steps": [
+            {
+              "uuid": "cdbfd84d-70ec-4327-a9a9-7a883b7873ed",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "95998cfc-a9b4-49d2-95c4-976fe52a92e2",
+                "title": "IBM QRadar: Get Reference Tables",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "b4f6dfcf-91fb-4a8d-b0b1-f9f26e912500",
+              "@type": "WorkflowStep",
+              "name": "Get Reference Tables",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "filter_string": "",
+                  "max_results": 100,
+                  "query.fields": ""
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_reference_tables",
+                "operationTitle": "Get Reference Tables",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "0da4895f-aaa1-4388-b0d6-28e92914e6e8",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Reference Tables",
+              "sourceStep": "/api/3/workflow_steps/cdbfd84d-70ec-4327-a9a9-7a883b7873ed",
+              "targetStep": "/api/3/workflow_steps/b4f6dfcf-91fb-4a8d-b0b1-f9f26e912500"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "5c152a06-81dd-4a33-860b-4fe35a67de3f",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Deletes a specific reference table and optionally purges its content from QRadar based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the 'Get Reference Tables' operation.",
+          "name": "Delete or Purge Reference Table",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/f2651852-e8c4-4f15-975d-7456143384a1",
+          "steps": [
+            {
+              "uuid": "f2651852-e8c4-4f15-975d-7456143384a1",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "db8c5252-7813-4b75-912c-2d34e713ca20",
+                "title": "IBM QRadar: Delete or Purge Reference Table",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "4e82ca06-a6fc-46b7-9b38-fa5ddf6418df",
+              "@type": "WorkflowStep",
+              "name": "Delete or Purge Reference Table",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "path.name": "",
+                  "query.purge_only": "false",
+                  "query.fields": "",
+                  "query.namespace": ""
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "delete_reference_table",
+                "operationTitle": "Delete or Purge Reference Table",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "a59f0f90-28a5-41c1-9790-e5f592d5b791",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Delete or Purge Reference Table",
+              "sourceStep": "/api/3/workflow_steps/f2651852-e8c4-4f15-975d-7456143384a1",
+              "targetStep": "/api/3/workflow_steps/4e82ca06-a6fc-46b7-9b38-fa5ddf6418df"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "f87a8d56-56d7-4781-9b7a-e831452d2816",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves the record details (elements) of a specific reference table based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the 'Get Reference Tables' operation.",
+          "name": "Get Table Elements",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/b1d7ba77-06de-40a6-8491-592224ccb1a4",
+          "steps": [
+            {
+              "uuid": "b1d7ba77-06de-40a6-8491-592224ccb1a4",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "5688b554-fd02-480f-bdce-988b7a070541",
+                "title": "IBM QRadar: Get Table Elements",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "b64e79b2-a456-4893-af1c-4a703b4db933",
+              "@type": "WorkflowStep",
+              "name": "Get Table Elements",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "path.name": "",
+                  "max_results": 100,
+                  "query.fields": "",
+                  "query.namespace": ""
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_table_elements",
+                "operationTitle": "Get Table Elements",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "69f4273b-d4c6-4cac-99d2-432ec2c8a9a8",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Table Elements",
+              "sourceStep": "/api/3/workflow_steps/b1d7ba77-06de-40a6-8491-592224ccb1a4",
+              "targetStep": "/api/3/workflow_steps/b64e79b2-a456-4893-af1c-4a703b4db933"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "601ece89-2f46-400c-8b89-be9a592db111",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Adds or updates an element in the specified reference table based on the reference table name, outer key, inner key, and other input parameters you have specified.",
+          "name": "Add or Update Table Element",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/c1f174c7-ec01-4000-b848-b75c7f7a8490",
+          "steps": [
+            {
+              "uuid": "c1f174c7-ec01-4000-b848-b75c7f7a8490",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "22fef674-9def-4d39-8ba4-e0511d3ce080",
+                "title": "IBM QRadar: Add or Update Table Element",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "d6a0bbff-179a-4b2b-b5c3-42d80333bbdd",
+              "@type": "WorkflowStep",
+              "name": "Add or Update Table Element",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "path.name": "",
+                  "query.outer_key": "",
+                  "query.inner_key": "",
+                  "query.value": "",
+                  "query.domain_id": "",
+                  "query.source": "FortiSOAR",
+                  "query.fields": "",
+                  "query.namespace": ""
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "add_table_element",
+                "operationTitle": "Add or Update Table Element",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "678c63d0-661f-41c3-86bd-b40f83f997f2",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Add or Update Table Element",
+              "sourceStep": "/api/3/workflow_steps/c1f174c7-ec01-4000-b848-b75c7f7a8490",
+              "targetStep": "/api/3/workflow_steps/d6a0bbff-179a-4b2b-b5c3-42d80333bbdd"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "c2212277-13eb-4e85-bd14-1bbca530195c",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Specify the element to be deleted from a reference table on Qradar based on the input parameters specified.",
+          "name": "Delete Table Element",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/7c300ea3-f5ee-45b3-9fec-02d4495e8baf",
+          "steps": [
+            {
+              "uuid": "7c300ea3-f5ee-45b3-9fec-02d4495e8baf",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "bf14d827-c5e4-461b-91fd-b9da93d61d9a",
+                "title": "IBM QRadar: Delete Table Element",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "0d672226-c63d-4b50-af7b-ac5776d5e1c8",
+              "@type": "WorkflowStep",
+              "name": "Delete Table Element",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "path.name": "",
+                  "path.outer_key": "",
+                  "path.inner_key": "",
+                  "query.value": "",
+                  "query.domain_id": "",
+                  "query.fields": "",
+                  "query.namespace": ""
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "delete_table_element",
+                "operationTitle": "Delete Table Element",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "a17908d9-b4cf-4617-980f-f6c1e5cb02d9",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Delete Table Element",
+              "sourceStep": "/api/3/workflow_steps/7c300ea3-f5ee-45b3-9fec-02d4495e8baf",
+              "targetStep": "/api/3/workflow_steps/0d672226-c63d-4b50-af7b-ac5776d5e1c8"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "5d74dde4-8d88-49ac-9bd3-fef2636892a5",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves a list of offenses from the QRadar server based on the filter string and start datetime that you have specified.",
+          "name": "Fetch Offenses from QRadar",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/25da3e71-41d0-4ebb-89d7-ccbbf65a67e2",
+          "steps": [
+            {
+              "uuid": "25da3e71-41d0-4ebb-89d7-ccbbf65a67e2",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "cc0db9d7-b9dd-44a0-9d8a-bfbf108c9484",
+                "title": "IBM QRadar: Fetch Offenses from QRadar",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "c6790d0f-e6c9-4796-85d0-67462e3c4ccd",
+              "@type": "WorkflowStep",
+              "name": "Fetch Offenses from QRadar",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": {
+                  "filter_string": "status=\"OPEN\""
+                },
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "fetch_offenses",
+                "operationTitle": "Fetch Offenses from QRadar",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "2e445851-e959-4c9e-8af3-327586242de9",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Fetch Offenses from QRadar",
+              "sourceStep": "/api/3/workflow_steps/25da3e71-41d0-4ebb-89d7-ccbbf65a67e2",
+              "targetStep": "/api/3/workflow_steps/c6790d0f-e6c9-4796-85d0-67462e3c4ccd"
+            }
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "uuid": "1dd7857f-d9c5-459a-bba1-c4e726422992",
+          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "triggerLimit": null,
+          "description": "Retrieves the MITRE mapping details associated with a QRadar offense from the QRadar server, based on the specified Offense ID.",
+          "name": "Get Mitre Mapping Related to an Offense",
+          "tag": "#IBM QRadar",
+          "recordTags": [
+            "qradar"
+          ],
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "parameters": [],
+          "synchronous": false,
+          "triggerStep": "/api/3/workflow_steps/6e10b852-8ba0-4a23-b300-607c11a9f2bc",
+          "steps": [
+            {
+              "uuid": "6e10b852-8ba0-4a23-b300-607c11a9f2bc",
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "route": "6a3fbc6d-1a76-47fb-b638-d47776c5c782",
+                "title": "IBM QRadar: Get Mitre Mapping Related to an Offense",
+                "resources": [
+                  "alerts"
+                ],
+                "inputVariables": [],
+                "step_variables": {
+                  "input": {
+                    "records": "{{vars.input.records[0]}}"
+                  }
+                },
+                "singleRecordExecution": false,
+                "noRecordExecution": true,
+                "executeButtonText": "Execute"
+              },
+              "left": "20",
+              "top": "20",
+              "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
+            },
+            {
+              "uuid": "d0a9b236-b968-4ae0-809c-44d61e26bc62",
+              "@type": "WorkflowStep",
+              "name": "Get Mitre Mapping Related to an Offense",
+              "description": null,
+              "status": null,
+              "arguments": {
+                "name": "IBM QRadar",
+                "config": "''",
+                "params": [],
+                "version": "1.6.3",
+                "connector": "qradar",
+                "operation": "get_mitre_mapping_related_to_an_offense",
+                "operationTitle": "Get Mitre Mapping Related to an Offense",
+                "step_variables": {
+                  "output_data": "{{vars.result}}"
+                }
+              },
+              "left": "188",
+              "top": "120",
+              "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "uuid": "1e1a2451-a3f6-4d0e-a270-fda76c7011f2",
+              "label": null,
+              "isExecuted": false,
+              "name": "Start-> Get Mitre Mapping Related to an Offense",
+              "sourceStep": "/api/3/workflow_steps/6e10b852-8ba0-4a23-b300-607c11a9f2bc",
+              "targetStep": "/api/3/workflow_steps/d0a9b236-b968-4ae0-809c-44d61e26bc62"
+            }
           ]
         }
       ]
     }
-  ],
-  "exported_tags": [
-    "qradar",
-    "dataingestion",
-    "ingest",
-    "create",
-    "fetch",
-    "qradar app"
   ]
 }

--- a/qradar/playbooks/playbooks.json
+++ b/qradar/playbooks/playbooks.json
@@ -2,7 +2,7 @@
   "type": "workflow_collections",
   "data": [
     {
-      "uuid": "fcec4c33-b791-4e17-919f-e8657549c3d6",
+      "uuid": "f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
       "@type": "WorkflowCollection",
       "name": "Sample - IBM QRadar - 1.6.3",
       "description": "IBM QRadar is an enterprise security information and event management (SIEM) product. Fortinet FortiSOAR connector for IBM QRadar allows users to invoke QRadar API, perform Ariel Queries and operations like Get Offense,related events,update and close offenses.",
@@ -14,8 +14,8 @@
       "workflows": [
         {
           "@type": "Workflow",
-          "uuid": "afb7ca2a-fc2b-4b05-a231-da5d11097e75",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "96204bb2-e09c-4808-bfb8-de1ecbeb65f2",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves a list of offenses from the QRadar server based on the filter string that you have specified.",
           "name": "Get Offenses from QRadar",
@@ -28,16 +28,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/d79845af-69e5-4d3e-84dc-ddb3bf5c4943",
+          "triggerStep": "/api/3/workflow_steps/1a7433e5-c94c-4bf4-99d7-71db45f99fd6",
           "steps": [
             {
-              "uuid": "d79845af-69e5-4d3e-84dc-ddb3bf5c4943",
+              "uuid": "1a7433e5-c94c-4bf4-99d7-71db45f99fd6",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "7f73cf9d-3dc9-4c3b-9ba2-53f7d7b3b834",
+                "route": "9ab8dc31-9913-4f00-91a9-034bbc8be5d5",
                 "title": "IBM QRadar: Get Offenses from QRadar",
                 "resources": [
                   "alerts"
@@ -57,7 +57,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "de6818c7-a9a9-4818-b3ea-71f5164b70d1",
+              "uuid": "8ed7acae-f294-4cc5-8903-8a1d57f42626",
               "@type": "WorkflowStep",
               "name": "Get Offenses from QRadar",
               "description": null,
@@ -84,19 +84,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "fb68977f-5918-40b9-a6d3-8ae13c82d4d6",
+              "uuid": "3a63e644-6e86-4c1d-8a29-7984b03bae65",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Offenses from QRadar",
-              "sourceStep": "/api/3/workflow_steps/d79845af-69e5-4d3e-84dc-ddb3bf5c4943",
-              "targetStep": "/api/3/workflow_steps/de6818c7-a9a9-4818-b3ea-71f5164b70d1"
+              "sourceStep": "/api/3/workflow_steps/1a7433e5-c94c-4bf4-99d7-71db45f99fd6",
+              "targetStep": "/api/3/workflow_steps/8ed7acae-f294-4cc5-8903-8a1d57f42626"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "59849093-a3d8-4c5e-ada8-2ec1c0a3f4d2",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "ca721043-b542-4e71-8fc1-0189a7a0a524",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Executes an Ariel query on the QRadar server. QRadar uses the Ariel Query Language (AQL) to search for offenses or events based on query parameters.",
           "name": "Make an Ariel Query to QRadar",
@@ -109,16 +109,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/761d997c-8d70-482f-a956-ed1027fa783d",
+          "triggerStep": "/api/3/workflow_steps/538c732a-fb03-4ba2-8adb-c98f6b78ed44",
           "steps": [
             {
-              "uuid": "761d997c-8d70-482f-a956-ed1027fa783d",
+              "uuid": "538c732a-fb03-4ba2-8adb-c98f6b78ed44",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "63fa53de-96e3-432b-af02-8664cf96e7b2",
+                "route": "43d3e9d5-f0d4-4663-a818-087ef0154b43",
                 "title": "IBM QRadar: Make an Ariel Query to QRadar",
                 "resources": [
                   "alerts"
@@ -138,7 +138,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "00dff571-07f8-4f26-9fd5-a15ee5f5052e",
+              "uuid": "e670f74a-baf9-42ce-b566-b5c5dee6f764",
               "@type": "WorkflowStep",
               "name": "Make an Ariel Query to QRadar",
               "description": null,
@@ -163,19 +163,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "0fb7cd18-fe30-4f8b-aa4a-ef305b1f7dbb",
+              "uuid": "c461bd49-a89d-417d-a565-a0ed9931ea1e",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Make an Ariel Query to QRadar",
-              "sourceStep": "/api/3/workflow_steps/761d997c-8d70-482f-a956-ed1027fa783d",
-              "targetStep": "/api/3/workflow_steps/00dff571-07f8-4f26-9fd5-a15ee5f5052e"
+              "sourceStep": "/api/3/workflow_steps/538c732a-fb03-4ba2-8adb-c98f6b78ed44",
+              "targetStep": "/api/3/workflow_steps/e670f74a-baf9-42ce-b566-b5c5dee6f764"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "b5f1a33b-b650-41c8-b654-215e77db1606",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "7028cf20-144a-4490-ad52-8a17b591fb0b",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves a list of closing reasons associated with all offenses from the QRadar server.",
           "name": "Get Offense Closing Reasons",
@@ -188,16 +188,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/ad03f884-4198-4b77-8868-121697cc791b",
+          "triggerStep": "/api/3/workflow_steps/d1347bac-1da3-41dc-a3ad-80d450a38a36",
           "steps": [
             {
-              "uuid": "ad03f884-4198-4b77-8868-121697cc791b",
+              "uuid": "d1347bac-1da3-41dc-a3ad-80d450a38a36",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "f6c0d8bf-19e5-4504-8df0-525d1a451c52",
+                "route": "4c3c911e-5e71-4e2c-a7cd-b08971fabbaa",
                 "title": "IBM QRadar: Get Offense Closing Reasons",
                 "resources": [
                   "alerts"
@@ -217,7 +217,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "7722e068-6356-4e0d-a904-f658197ead43",
+              "uuid": "970e2e4f-4cb7-40cd-b16a-135d3e18acf5",
               "@type": "WorkflowStep",
               "name": "Get Offense Closing Reasons",
               "description": null,
@@ -242,19 +242,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "d15b5ede-7d12-4e04-a0c1-89427b4dcc11",
+              "uuid": "bcf1f109-89fb-454d-8501-dae5fd521380",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Offense Closing Reasons",
-              "sourceStep": "/api/3/workflow_steps/ad03f884-4198-4b77-8868-121697cc791b",
-              "targetStep": "/api/3/workflow_steps/7722e068-6356-4e0d-a904-f658197ead43"
+              "sourceStep": "/api/3/workflow_steps/d1347bac-1da3-41dc-a3ad-80d450a38a36",
+              "targetStep": "/api/3/workflow_steps/970e2e4f-4cb7-40cd-b16a-135d3e18acf5"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "5d80d7d7-82b7-4510-98ac-1b1eda4f5dc1",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "c927f519-b9ef-4b3d-8b6f-acb02dbdafc4",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves a list containing IDs of all the offense types from the QRadar server.",
           "name": "Get Offense Types",
@@ -267,16 +267,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/dd0a61b2-ffe8-4a48-a961-6620298e3676",
+          "triggerStep": "/api/3/workflow_steps/66ec087e-a00c-4066-8201-5e3f4f6b5143",
           "steps": [
             {
-              "uuid": "dd0a61b2-ffe8-4a48-a961-6620298e3676",
+              "uuid": "66ec087e-a00c-4066-8201-5e3f4f6b5143",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "0c28a5c5-4802-4d18-b534-737e7e193951",
+                "route": "c2925ae4-dd56-437f-b373-84c0ff9e32a6",
                 "title": "IBM QRadar: Get Offense Types",
                 "resources": [
                   "alerts"
@@ -296,7 +296,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "a7b8bf4c-5b0d-45db-82b2-cdbcf086652a",
+              "uuid": "04e43afa-7e26-4035-8298-71e277fa8d33",
               "@type": "WorkflowStep",
               "name": "Get Offense Types",
               "description": null,
@@ -321,19 +321,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "ea1f4473-9cc4-4f45-9bcf-20f01dcad056",
+              "uuid": "539ef422-76f1-4cb5-872e-4bf3fbade0c4",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Offense Types",
-              "sourceStep": "/api/3/workflow_steps/dd0a61b2-ffe8-4a48-a961-6620298e3676",
-              "targetStep": "/api/3/workflow_steps/a7b8bf4c-5b0d-45db-82b2-cdbcf086652a"
+              "sourceStep": "/api/3/workflow_steps/66ec087e-a00c-4066-8201-5e3f4f6b5143",
+              "targetStep": "/api/3/workflow_steps/04e43afa-7e26-4035-8298-71e277fa8d33"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "9f67dd4a-c931-45f1-94ac-1e24aa69b9b4",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "1b65ec9a-ce2b-4a54-ba5d-cf9d6c42ddc4",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves a list of notes associated with a specified offense in QRadar based on the offense ID you have specified.",
           "name": "Get Offense Notes",
@@ -346,16 +346,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/336e6603-d427-4e42-bd84-485e862a1d6d",
+          "triggerStep": "/api/3/workflow_steps/40b694ff-200f-4964-9f93-1d705307c734",
           "steps": [
             {
-              "uuid": "336e6603-d427-4e42-bd84-485e862a1d6d",
+              "uuid": "40b694ff-200f-4964-9f93-1d705307c734",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "4ee5ce0b-b801-4609-93a1-30dcd46d38dd",
+                "route": "112ed49e-7262-4905-9dee-d6abc752c6f4",
                 "title": "IBM QRadar: Get Offense Notes",
                 "resources": [
                   "alerts"
@@ -375,7 +375,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "5c93c264-7bf9-49e8-aaaf-36b2cdaa4d4a",
+              "uuid": "50ab5d2f-4425-417c-8f49-4eeac9f203c6",
               "@type": "WorkflowStep",
               "name": "Get Offense Notes",
               "description": null,
@@ -400,19 +400,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "cf4bd84e-5ebe-4cb1-b6a9-d19d2646338d",
+              "uuid": "137974e4-87ed-4f3a-81cd-1af1682781af",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Offense Notes",
-              "sourceStep": "/api/3/workflow_steps/336e6603-d427-4e42-bd84-485e862a1d6d",
-              "targetStep": "/api/3/workflow_steps/5c93c264-7bf9-49e8-aaaf-36b2cdaa4d4a"
+              "sourceStep": "/api/3/workflow_steps/40b694ff-200f-4964-9f93-1d705307c734",
+              "targetStep": "/api/3/workflow_steps/50ab5d2f-4425-417c-8f49-4eeac9f203c6"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "fa6dc8c2-a89e-4261-b4e9-e73f06f5c3ad",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "0cf593d9-ca2b-45c3-af7c-0ac439bddda1",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Closes an offense on the QRadar server based on the offense ID that you have specified.",
           "name": "Close Offense",
@@ -425,16 +425,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/99d9bee0-9a59-4e1a-ba38-31a5dc7c2920",
+          "triggerStep": "/api/3/workflow_steps/bc4ce28f-2f3a-44da-992c-b05479bcc192",
           "steps": [
             {
-              "uuid": "99d9bee0-9a59-4e1a-ba38-31a5dc7c2920",
+              "uuid": "bc4ce28f-2f3a-44da-992c-b05479bcc192",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "867c639a-ad9c-425f-9a65-66d6b013935f",
+                "route": "18e8c6bf-6a0d-46ee-a5b7-1e35ce53835b",
                 "title": "IBM QRadar: Close Offense",
                 "resources": [
                   "alerts"
@@ -454,7 +454,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "630bc037-6244-4583-b3be-557e7467cfbb",
+              "uuid": "b2f4423e-eda0-4cc9-85f2-e74b32262f79",
               "@type": "WorkflowStep",
               "name": "Close Offense",
               "description": null,
@@ -479,19 +479,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "f5c52544-c367-4570-afea-f1cb6d2329d2",
+              "uuid": "2c5bdf49-e6dc-4e05-8a34-fb619be9a977",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Close Offense",
-              "sourceStep": "/api/3/workflow_steps/99d9bee0-9a59-4e1a-ba38-31a5dc7c2920",
-              "targetStep": "/api/3/workflow_steps/630bc037-6244-4583-b3be-557e7467cfbb"
+              "sourceStep": "/api/3/workflow_steps/bc4ce28f-2f3a-44da-992c-b05479bcc192",
+              "targetStep": "/api/3/workflow_steps/b2f4423e-eda0-4cc9-85f2-e74b32262f79"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "34cc1ad1-7ff1-4406-8fef-9d76fc98b936",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "c702ff47-d72c-4a6b-855b-b268710cfec8",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Creates a note for a specified offense in QRadar based on the offense ID you have specified.",
           "name": "Create Note",
@@ -504,16 +504,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/cc59a9c6-4b69-45bc-a2b4-c433a6060096",
+          "triggerStep": "/api/3/workflow_steps/876a96b0-b553-4cb0-87fd-02ca913befc3",
           "steps": [
             {
-              "uuid": "cc59a9c6-4b69-45bc-a2b4-c433a6060096",
+              "uuid": "876a96b0-b553-4cb0-87fd-02ca913befc3",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "39b5373f-1814-43fc-931c-1191600d581d",
+                "route": "fedac73a-6054-4290-8ae4-8e9db33e3c11",
                 "title": "IBM QRadar: Create Note",
                 "resources": [
                   "alerts"
@@ -533,7 +533,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "aca730e0-c90d-4f3d-836d-433109b5a9c5",
+              "uuid": "6f0b68e9-1e75-4b49-9c00-b4b64846ef78",
               "@type": "WorkflowStep",
               "name": "Create Note",
               "description": null,
@@ -558,19 +558,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "eb1d9aeb-a854-4d11-8c8f-303f552bba7f",
+              "uuid": "a2c0b16f-3223-4b6a-83b7-6dc9a58e045a",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Create Note",
-              "sourceStep": "/api/3/workflow_steps/cc59a9c6-4b69-45bc-a2b4-c433a6060096",
-              "targetStep": "/api/3/workflow_steps/aca730e0-c90d-4f3d-836d-433109b5a9c5"
+              "sourceStep": "/api/3/workflow_steps/876a96b0-b553-4cb0-87fd-02ca913befc3",
+              "targetStep": "/api/3/workflow_steps/6f0b68e9-1e75-4b49-9c00-b4b64846ef78"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "dbd3be55-c280-469f-ace0-15b6b909b897",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "55090912-ce47-4a87-9fa5-9a92fe25cb86",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves details of events associated with a QRadar offense, from the QRadar server, based on the QRadar offense ID that you have specified.",
           "name": "Get Events Related to an Offense",
@@ -583,16 +583,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/666d0b59-195a-42b6-9e4f-8e79c8613a29",
+          "triggerStep": "/api/3/workflow_steps/5ceed706-9ef7-48d5-b48e-59e62ed2a961",
           "steps": [
             {
-              "uuid": "666d0b59-195a-42b6-9e4f-8e79c8613a29",
+              "uuid": "5ceed706-9ef7-48d5-b48e-59e62ed2a961",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "f3e3c299-4558-4293-bbd3-44e5b4c85135",
+                "route": "f164f4a3-2dc7-40a1-908e-0a6a26946a54",
                 "title": "IBM QRadar: Get Events Related to an Offense",
                 "resources": [
                   "alerts"
@@ -612,7 +612,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "277c9cc4-70a4-41bb-b9ab-a40258f117d6",
+              "uuid": "43e954ea-c477-46d0-9f6d-c06ae2006b6a",
               "@type": "WorkflowStep",
               "name": "Get Events Related to an Offense",
               "description": null,
@@ -642,19 +642,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "8c1dec69-db32-4013-ab08-f4d414ab3367",
+              "uuid": "30849003-085d-43e3-951c-6c204f97561d",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Events Related to an Offense",
-              "sourceStep": "/api/3/workflow_steps/666d0b59-195a-42b6-9e4f-8e79c8613a29",
-              "targetStep": "/api/3/workflow_steps/277c9cc4-70a4-41bb-b9ab-a40258f117d6"
+              "sourceStep": "/api/3/workflow_steps/5ceed706-9ef7-48d5-b48e-59e62ed2a961",
+              "targetStep": "/api/3/workflow_steps/43e954ea-c477-46d0-9f6d-c06ae2006b6a"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "5c455226-ed8c-4862-a518-0366b89f043f",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "66e3226c-fe52-48f6-9028-f30ca541ddc4",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves IP address details associated with source address IDs from the QRadar server, based on the source address IDs that you have specified",
           "name": "Get Source IP Addresses",
@@ -667,16 +667,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/98e9dae4-e3f0-41e8-b2ce-a8f079df38f4",
+          "triggerStep": "/api/3/workflow_steps/4b25dfd6-19a7-438b-9f5f-1fd074a7d359",
           "steps": [
             {
-              "uuid": "98e9dae4-e3f0-41e8-b2ce-a8f079df38f4",
+              "uuid": "4b25dfd6-19a7-438b-9f5f-1fd074a7d359",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "c9aec81a-3b5a-4599-837f-67617d152bbf",
+                "route": "1c265a49-4f1d-400f-8cee-2e9c8771029f",
                 "title": "IBM QRadar: Get Source IP Addresses",
                 "resources": [
                   "alerts"
@@ -696,7 +696,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "3555b620-56a5-4109-b4e8-0c8166c41f59",
+              "uuid": "0a78b245-aecc-40a8-810b-691b8ea30cf7",
               "@type": "WorkflowStep",
               "name": "Get Source IP Addresses",
               "description": null,
@@ -721,19 +721,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "24525151-5e70-4cf1-a439-98884a453425",
+              "uuid": "af81a5fd-d3c1-4463-8101-6806af0598b4",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Source IP Addresses",
-              "sourceStep": "/api/3/workflow_steps/98e9dae4-e3f0-41e8-b2ce-a8f079df38f4",
-              "targetStep": "/api/3/workflow_steps/3555b620-56a5-4109-b4e8-0c8166c41f59"
+              "sourceStep": "/api/3/workflow_steps/4b25dfd6-19a7-438b-9f5f-1fd074a7d359",
+              "targetStep": "/api/3/workflow_steps/0a78b245-aecc-40a8-810b-691b8ea30cf7"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "24396842-f02d-4d04-91b9-54c25440bb34",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "0b0bca87-8aba-4086-a316-42696298aa2f",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves IP address details associated with the destination address IDs from the QRadar server, based on the destination address IDs that you have specified",
           "name": "Get Destination IP Addresses",
@@ -746,16 +746,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/bb245c83-907d-4357-a127-5264979ad8d8",
+          "triggerStep": "/api/3/workflow_steps/26b2f0b5-c005-4345-bb46-7a20526d9ffe",
           "steps": [
             {
-              "uuid": "bb245c83-907d-4357-a127-5264979ad8d8",
+              "uuid": "26b2f0b5-c005-4345-bb46-7a20526d9ffe",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "b4bc81d0-e4c2-4bca-b5bf-96dd283cbc3f",
+                "route": "479cca62-f5d2-402c-9737-85a55b43fef7",
                 "title": "IBM QRadar: Get Destination IP Addresses",
                 "resources": [
                   "alerts"
@@ -775,7 +775,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "d3852c39-2727-47b8-a322-28d20279472e",
+              "uuid": "f58d8f78-016d-4ad1-8966-859c16e827cb",
               "@type": "WorkflowStep",
               "name": "Get Destination IP Addresses",
               "description": null,
@@ -800,19 +800,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "92de8619-f17d-4104-b043-233101a060de",
+              "uuid": "5252c2d2-0430-4f9c-ac42-c652af911d64",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Destination IP Addresses",
-              "sourceStep": "/api/3/workflow_steps/bb245c83-907d-4357-a127-5264979ad8d8",
-              "targetStep": "/api/3/workflow_steps/d3852c39-2727-47b8-a322-28d20279472e"
+              "sourceStep": "/api/3/workflow_steps/26b2f0b5-c005-4345-bb46-7a20526d9ffe",
+              "targetStep": "/api/3/workflow_steps/f58d8f78-016d-4ad1-8966-859c16e827cb"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "4bbd3ddd-6f33-4b62-83cf-77f095d7c876",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "0ba8fbe4-45b0-4730-8030-10a7c98cd448",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Invokes a function to Get or Post an API endpoint on the QRadar server.",
           "name": "Invoke QRadar REST API",
@@ -825,16 +825,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/f6a80c87-eadd-4072-b44b-79bf8a39f919",
+          "triggerStep": "/api/3/workflow_steps/b18637f9-8632-4935-83e1-d4fbff7baab3",
           "steps": [
             {
-              "uuid": "f6a80c87-eadd-4072-b44b-79bf8a39f919",
+              "uuid": "b18637f9-8632-4935-83e1-d4fbff7baab3",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "54d161bb-8778-4116-9efa-862a2c723688",
+                "route": "2f41d0f8-decb-4053-8497-77b2cc088053",
                 "title": "IBM QRadar: Invoke QRadar REST API",
                 "resources": [
                   "alerts"
@@ -854,7 +854,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "638fb491-4bb2-45bc-bc8b-757840323316",
+              "uuid": "6a0af79d-245e-43f6-810f-8a9fa7a291bc",
               "@type": "WorkflowStep",
               "name": "Invoke QRadar REST API",
               "description": null,
@@ -881,19 +881,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "0ee0414e-3126-4d01-b5e9-0ecc2edc5517",
+              "uuid": "4d0e4edb-587d-4f97-96e2-40fa91d6add5",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Invoke QRadar REST API",
-              "sourceStep": "/api/3/workflow_steps/f6a80c87-eadd-4072-b44b-79bf8a39f919",
-              "targetStep": "/api/3/workflow_steps/638fb491-4bb2-45bc-bc8b-757840323316"
+              "sourceStep": "/api/3/workflow_steps/b18637f9-8632-4935-83e1-d4fbff7baab3",
+              "targetStep": "/api/3/workflow_steps/6a0af79d-245e-43f6-810f-8a9fa7a291bc"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "ce4c3f21-e260-4cdf-ab1a-154d4fa42023",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "d27f978f-8d66-45ca-89db-221c2bbc695e",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Adds or deletes the content that you have specified from a reference set on QRadar.",
           "name": "Manipulate Reference Set Content",
@@ -906,16 +906,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/3317a8dc-59bb-4f22-a723-95b3c33605bf",
+          "triggerStep": "/api/3/workflow_steps/5bdb663d-943e-455b-ab5b-e0353f51d314",
           "steps": [
             {
-              "uuid": "3317a8dc-59bb-4f22-a723-95b3c33605bf",
+              "uuid": "5bdb663d-943e-455b-ab5b-e0353f51d314",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "59737e72-05a3-4571-bed3-dd04b079d6cb",
+                "route": "28d155f5-708c-4439-9b99-a4e575015df4",
                 "title": "IBM QRadar: Manipulate Reference Set Content",
                 "resources": [
                   "alerts"
@@ -935,7 +935,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "2459f1a2-c848-4b88-bb4b-63d7e186ce47",
+              "uuid": "de410a7e-1881-47b8-810b-0dcbf7cf7d4a",
               "@type": "WorkflowStep",
               "name": "Manipulate Reference Set Content",
               "description": null,
@@ -962,19 +962,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "283d3ef1-6dde-44b0-a6f2-b64c258bcb4d",
+              "uuid": "c1d67f6c-5634-41a8-a4c6-e8d0d04cbed4",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Manipulate Reference Set Content",
-              "sourceStep": "/api/3/workflow_steps/3317a8dc-59bb-4f22-a723-95b3c33605bf",
-              "targetStep": "/api/3/workflow_steps/2459f1a2-c848-4b88-bb4b-63d7e186ce47"
+              "sourceStep": "/api/3/workflow_steps/5bdb663d-943e-455b-ab5b-e0353f51d314",
+              "targetStep": "/api/3/workflow_steps/de410a7e-1881-47b8-810b-0dcbf7cf7d4a"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "a5d49b52-8589-458f-8ba8-feb34f8caee3",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "224f2d19-3f67-46e5-bbf5-598602d1adb7",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves a detailed list of available asset properties or specific available asset properties from QRadar based on input parameters specified.",
           "name": "Get Assets Properties",
@@ -987,16 +987,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/58e855a9-c794-4877-9a10-2bae3a23ea4d",
+          "triggerStep": "/api/3/workflow_steps/4be1e9e9-f997-41be-b3fb-094b36147d39",
           "steps": [
             {
-              "uuid": "58e855a9-c794-4877-9a10-2bae3a23ea4d",
+              "uuid": "4be1e9e9-f997-41be-b3fb-094b36147d39",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "2d7bab81-a571-458c-bccf-f712f01fcc4f",
+                "route": "529bfe42-07a7-4754-9dd1-03d25f2a6237",
                 "title": "IBM QRadar: Get Assets Properties",
                 "resources": [
                   "alerts"
@@ -1016,7 +1016,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "2f2b5445-0603-4b66-9518-17d5146c2f05",
+              "uuid": "0321cc13-ef16-475d-9d76-5b8d628eccc3",
               "@type": "WorkflowStep",
               "name": "Get Assets Properties",
               "description": null,
@@ -1045,19 +1045,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "277bde2e-abe8-4630-ab0b-e0ad8220bab3",
+              "uuid": "b33e757b-7229-48cc-9774-4fa0bc89da2e",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Assets Properties",
-              "sourceStep": "/api/3/workflow_steps/58e855a9-c794-4877-9a10-2bae3a23ea4d",
-              "targetStep": "/api/3/workflow_steps/2f2b5445-0603-4b66-9518-17d5146c2f05"
+              "sourceStep": "/api/3/workflow_steps/4be1e9e9-f997-41be-b3fb-094b36147d39",
+              "targetStep": "/api/3/workflow_steps/0321cc13-ef16-475d-9d76-5b8d628eccc3"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "2772d84a-2077-4f1d-9720-b25f871858ff",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "0ccb17f1-34a0-405c-9e3e-ba1be46a0610",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves a detailed list of all available assets or specific available assets from QRadar based on input parameters specified.",
           "name": "Get Assets",
@@ -1070,16 +1070,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/8dc6f005-d64d-438d-89e6-d3b711e7c8b4",
+          "triggerStep": "/api/3/workflow_steps/a1a51d66-060e-4d50-adce-82f21384e57b",
           "steps": [
             {
-              "uuid": "8dc6f005-d64d-438d-89e6-d3b711e7c8b4",
+              "uuid": "a1a51d66-060e-4d50-adce-82f21384e57b",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "a31d83a8-a93f-4f01-a5cd-7ffc72c4237f",
+                "route": "91ec76b3-f6ca-42d1-acd0-fb5822bb62cb",
                 "title": "IBM QRadar: Get Assets",
                 "resources": [
                   "alerts"
@@ -1099,7 +1099,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "478bddc3-aeb0-4777-9808-230c37943dee",
+              "uuid": "318833ad-7e20-4485-b77e-8d5928befd46",
               "@type": "WorkflowStep",
               "name": "Get Assets",
               "description": null,
@@ -1129,19 +1129,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "59721a26-4b94-457b-88a7-d2473130a4ec",
+              "uuid": "ffbb843f-8287-4ea5-9bbf-c59d4d77e58a",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Assets",
-              "sourceStep": "/api/3/workflow_steps/8dc6f005-d64d-438d-89e6-d3b711e7c8b4",
-              "targetStep": "/api/3/workflow_steps/478bddc3-aeb0-4777-9808-230c37943dee"
+              "sourceStep": "/api/3/workflow_steps/a1a51d66-060e-4d50-adce-82f21384e57b",
+              "targetStep": "/api/3/workflow_steps/318833ad-7e20-4485-b77e-8d5928befd46"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "0f64582e-4ce9-48c3-a970-b38bb9b6fd35",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "f8569029-17b3-4299-965c-c30e7c9ca0c8",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Updates the attributes of a specific asset on the QRadar server based on the asset ID and asset properties you have specified. Note: You can retrieve the list of asset properties using the 'Get Assets Properties' operation.",
           "name": "Update Asset",
@@ -1154,16 +1154,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/df0480f0-56c2-491f-9a15-c86007fd8b26",
+          "triggerStep": "/api/3/workflow_steps/546ba15d-86de-4d53-a9d5-e2392b07f786",
           "steps": [
             {
-              "uuid": "df0480f0-56c2-491f-9a15-c86007fd8b26",
+              "uuid": "546ba15d-86de-4d53-a9d5-e2392b07f786",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "cbb61fea-0761-4f3e-a587-868977f08dcc",
+                "route": "a5465bb2-a865-4683-8723-76e690158779",
                 "title": "IBM QRadar: Update Asset",
                 "resources": [
                   "alerts"
@@ -1183,7 +1183,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "79985cd1-5d92-4908-890f-41773227ac20",
+              "uuid": "2a99f620-7f46-4d42-a156-25034b6cae71",
               "@type": "WorkflowStep",
               "name": "Update Asset",
               "description": null,
@@ -1219,19 +1219,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "e2853349-7922-4e4c-975d-07e09faef301",
+              "uuid": "b200427b-22a3-4c07-9c2d-ce14b24eae9a",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Update Asset",
-              "sourceStep": "/api/3/workflow_steps/df0480f0-56c2-491f-9a15-c86007fd8b26",
-              "targetStep": "/api/3/workflow_steps/79985cd1-5d92-4908-890f-41773227ac20"
+              "sourceStep": "/api/3/workflow_steps/546ba15d-86de-4d53-a9d5-e2392b07f786",
+              "targetStep": "/api/3/workflow_steps/2a99f620-7f46-4d42-a156-25034b6cae71"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "330893bb-c46b-4b07-9963-6312d047a337",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "51dc76d5-0c8f-4d50-a1e8-b99f71d5838c",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves a detailed list of all cases or specific cases from QRadar based on input parameters specified. Note: This action is supported on QRadar API version 7.0 and later.",
           "name": "Get Cases",
@@ -1244,16 +1244,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/f585e4d8-377f-4764-b212-2daae1c8ba8d",
+          "triggerStep": "/api/3/workflow_steps/6d0e5ffe-3e10-4f94-bcd9-6e44f30cba0c",
           "steps": [
             {
-              "uuid": "f585e4d8-377f-4764-b212-2daae1c8ba8d",
+              "uuid": "6d0e5ffe-3e10-4f94-bcd9-6e44f30cba0c",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "24ad07e3-c97c-4b2c-b4f1-aac02993efe2",
+                "route": "2e1ffe6c-7d68-4449-8c57-0a2a5526b03a",
                 "title": "IBM QRadar: Get Cases",
                 "resources": [
                   "alerts"
@@ -1273,7 +1273,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "b312ad5a-122c-4c34-a078-6d92100b04f4",
+              "uuid": "cc3dcc62-86ae-40f0-9b79-b2e09d0045ed",
               "@type": "WorkflowStep",
               "name": "Get Cases",
               "description": null,
@@ -1302,19 +1302,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "1231b7a8-f597-4750-97a5-74555302b6f3",
+              "uuid": "d3af79da-cd5a-4069-8876-50324b791708",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Cases",
-              "sourceStep": "/api/3/workflow_steps/f585e4d8-377f-4764-b212-2daae1c8ba8d",
-              "targetStep": "/api/3/workflow_steps/b312ad5a-122c-4c34-a078-6d92100b04f4"
+              "sourceStep": "/api/3/workflow_steps/6d0e5ffe-3e10-4f94-bcd9-6e44f30cba0c",
+              "targetStep": "/api/3/workflow_steps/cc3dcc62-86ae-40f0-9b79-b2e09d0045ed"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "1e5613c6-292c-4ad1-867e-a6689019e0f4",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "e7985e0f-571a-43a0-9ff7-9e15a000c525",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Creates a new case on QRadar based on the case properties you have specified. Note: This action is supported on QRadar API version 7.0 and later.",
           "name": "Create Case",
@@ -1327,16 +1327,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/74f9d57f-19e6-4789-9d00-29b7bceb9752",
+          "triggerStep": "/api/3/workflow_steps/0221e445-e743-479b-a6fd-532fffbfd996",
           "steps": [
             {
-              "uuid": "74f9d57f-19e6-4789-9d00-29b7bceb9752",
+              "uuid": "0221e445-e743-479b-a6fd-532fffbfd996",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "3f5efbb3-f546-454f-b52a-f58b660313aa",
+                "route": "68f90f06-fc43-4435-98b7-730a3a155664",
                 "title": "IBM QRadar: Create Case",
                 "resources": [
                   "alerts"
@@ -1356,7 +1356,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "8a273394-97f6-40cb-8202-361a305e6651",
+              "uuid": "e59a7fed-9748-4605-99db-aae104cf7e66",
               "@type": "WorkflowStep",
               "name": "Create Case",
               "description": null,
@@ -1389,19 +1389,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "7f2019ce-2e1b-40c1-b67f-f6d7f762d996",
+              "uuid": "eb2b56d7-72f4-458e-b27d-775ac846e471",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Create Case",
-              "sourceStep": "/api/3/workflow_steps/74f9d57f-19e6-4789-9d00-29b7bceb9752",
-              "targetStep": "/api/3/workflow_steps/8a273394-97f6-40cb-8202-361a305e6651"
+              "sourceStep": "/api/3/workflow_steps/0221e445-e743-479b-a6fd-532fffbfd996",
+              "targetStep": "/api/3/workflow_steps/e59a7fed-9748-4605-99db-aae104cf7e66"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "f2e4c578-feb5-4ded-ab6e-a5d5f9f82763",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "7dec7ff5-6a06-4857-8268-e053b12804f8",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves a detailed list of all reference tables or specific reference tables from QRadar based on input parameters specified.",
           "name": "Get Reference Tables",
@@ -1414,16 +1414,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/cdbfd84d-70ec-4327-a9a9-7a883b7873ed",
+          "triggerStep": "/api/3/workflow_steps/e66d1ebc-e71e-47c5-b6aa-f839059a1a5a",
           "steps": [
             {
-              "uuid": "cdbfd84d-70ec-4327-a9a9-7a883b7873ed",
+              "uuid": "e66d1ebc-e71e-47c5-b6aa-f839059a1a5a",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "95998cfc-a9b4-49d2-95c4-976fe52a92e2",
+                "route": "f67be06f-f74f-4310-9d27-144deb0d15f6",
                 "title": "IBM QRadar: Get Reference Tables",
                 "resources": [
                   "alerts"
@@ -1443,7 +1443,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "b4f6dfcf-91fb-4a8d-b0b1-f9f26e912500",
+              "uuid": "d8569da6-8c28-4af8-95cb-ae697e41794f",
               "@type": "WorkflowStep",
               "name": "Get Reference Tables",
               "description": null,
@@ -1472,19 +1472,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "0da4895f-aaa1-4388-b0d6-28e92914e6e8",
+              "uuid": "1efc870e-4a09-41b7-8d68-76d2a3a20d8c",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Reference Tables",
-              "sourceStep": "/api/3/workflow_steps/cdbfd84d-70ec-4327-a9a9-7a883b7873ed",
-              "targetStep": "/api/3/workflow_steps/b4f6dfcf-91fb-4a8d-b0b1-f9f26e912500"
+              "sourceStep": "/api/3/workflow_steps/e66d1ebc-e71e-47c5-b6aa-f839059a1a5a",
+              "targetStep": "/api/3/workflow_steps/d8569da6-8c28-4af8-95cb-ae697e41794f"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "5c152a06-81dd-4a33-860b-4fe35a67de3f",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "c386de1f-a0b4-4e0f-9987-06ce01bed1b4",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Deletes a specific reference table and optionally purges its content from QRadar based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the 'Get Reference Tables' operation.",
           "name": "Delete or Purge Reference Table",
@@ -1497,16 +1497,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/f2651852-e8c4-4f15-975d-7456143384a1",
+          "triggerStep": "/api/3/workflow_steps/9049f933-9b43-4631-ab57-188539c34313",
           "steps": [
             {
-              "uuid": "f2651852-e8c4-4f15-975d-7456143384a1",
+              "uuid": "9049f933-9b43-4631-ab57-188539c34313",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "db8c5252-7813-4b75-912c-2d34e713ca20",
+                "route": "62274b4a-db96-450f-9898-4042e753d078",
                 "title": "IBM QRadar: Delete or Purge Reference Table",
                 "resources": [
                   "alerts"
@@ -1526,7 +1526,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "4e82ca06-a6fc-46b7-9b38-fa5ddf6418df",
+              "uuid": "5325811d-340a-4102-9f3e-c13c796ed501",
               "@type": "WorkflowStep",
               "name": "Delete or Purge Reference Table",
               "description": null,
@@ -1556,19 +1556,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "a59f0f90-28a5-41c1-9790-e5f592d5b791",
+              "uuid": "d39beb93-a3ae-4a5b-af11-963567f13916",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Delete or Purge Reference Table",
-              "sourceStep": "/api/3/workflow_steps/f2651852-e8c4-4f15-975d-7456143384a1",
-              "targetStep": "/api/3/workflow_steps/4e82ca06-a6fc-46b7-9b38-fa5ddf6418df"
+              "sourceStep": "/api/3/workflow_steps/9049f933-9b43-4631-ab57-188539c34313",
+              "targetStep": "/api/3/workflow_steps/5325811d-340a-4102-9f3e-c13c796ed501"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "f87a8d56-56d7-4781-9b7a-e831452d2816",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "93be42f9-b43f-4eb9-bac9-b3b0ac442039",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves the record details (elements) of a specific reference table based on the reference table name you have specified. Note: You can retrieve names and details of reference tables using the 'Get Reference Tables' operation.",
           "name": "Get Table Elements",
@@ -1581,16 +1581,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/b1d7ba77-06de-40a6-8491-592224ccb1a4",
+          "triggerStep": "/api/3/workflow_steps/16d74b5c-255e-40bb-9a47-851fa57e9854",
           "steps": [
             {
-              "uuid": "b1d7ba77-06de-40a6-8491-592224ccb1a4",
+              "uuid": "16d74b5c-255e-40bb-9a47-851fa57e9854",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "5688b554-fd02-480f-bdce-988b7a070541",
+                "route": "5fafeb3e-0074-4dcb-bfd6-595c08e82505",
                 "title": "IBM QRadar: Get Table Elements",
                 "resources": [
                   "alerts"
@@ -1610,7 +1610,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "b64e79b2-a456-4893-af1c-4a703b4db933",
+              "uuid": "ec6b0a14-df36-4a99-8952-a921b2bd3c50",
               "@type": "WorkflowStep",
               "name": "Get Table Elements",
               "description": null,
@@ -1640,19 +1640,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "69f4273b-d4c6-4cac-99d2-432ec2c8a9a8",
+              "uuid": "26356100-bcb7-437c-aa66-1ee301aa27ad",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Get Table Elements",
-              "sourceStep": "/api/3/workflow_steps/b1d7ba77-06de-40a6-8491-592224ccb1a4",
-              "targetStep": "/api/3/workflow_steps/b64e79b2-a456-4893-af1c-4a703b4db933"
+              "sourceStep": "/api/3/workflow_steps/16d74b5c-255e-40bb-9a47-851fa57e9854",
+              "targetStep": "/api/3/workflow_steps/ec6b0a14-df36-4a99-8952-a921b2bd3c50"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "601ece89-2f46-400c-8b89-be9a592db111",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "c30156fb-635b-41d7-bb54-c18da0fdd211",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Adds or updates an element in the specified reference table based on the reference table name, outer key, inner key, and other input parameters you have specified.",
           "name": "Add or Update Table Element",
@@ -1665,16 +1665,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/c1f174c7-ec01-4000-b848-b75c7f7a8490",
+          "triggerStep": "/api/3/workflow_steps/30ae3a48-56e1-46a7-9750-4f9292ba0bd6",
           "steps": [
             {
-              "uuid": "c1f174c7-ec01-4000-b848-b75c7f7a8490",
+              "uuid": "30ae3a48-56e1-46a7-9750-4f9292ba0bd6",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "22fef674-9def-4d39-8ba4-e0511d3ce080",
+                "route": "50aab6fb-2977-4cab-ae97-098fd80bca4c",
                 "title": "IBM QRadar: Add or Update Table Element",
                 "resources": [
                   "alerts"
@@ -1694,7 +1694,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "d6a0bbff-179a-4b2b-b5c3-42d80333bbdd",
+              "uuid": "dd755454-4656-4c46-93b7-9f839c3ba959",
               "@type": "WorkflowStep",
               "name": "Add or Update Table Element",
               "description": null,
@@ -1728,19 +1728,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "678c63d0-661f-41c3-86bd-b40f83f997f2",
+              "uuid": "1c79d32b-b7a8-4dce-a4b1-34b30b0d5393",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Add or Update Table Element",
-              "sourceStep": "/api/3/workflow_steps/c1f174c7-ec01-4000-b848-b75c7f7a8490",
-              "targetStep": "/api/3/workflow_steps/d6a0bbff-179a-4b2b-b5c3-42d80333bbdd"
+              "sourceStep": "/api/3/workflow_steps/30ae3a48-56e1-46a7-9750-4f9292ba0bd6",
+              "targetStep": "/api/3/workflow_steps/dd755454-4656-4c46-93b7-9f839c3ba959"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "c2212277-13eb-4e85-bd14-1bbca530195c",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "9e1246e4-a39a-4fdc-adf7-ec83a434eb31",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Specify the element to be deleted from a reference table on Qradar based on the input parameters specified.",
           "name": "Delete Table Element",
@@ -1753,16 +1753,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/7c300ea3-f5ee-45b3-9fec-02d4495e8baf",
+          "triggerStep": "/api/3/workflow_steps/5f16baf8-ef2b-4121-8cf7-417be36f64ba",
           "steps": [
             {
-              "uuid": "7c300ea3-f5ee-45b3-9fec-02d4495e8baf",
+              "uuid": "5f16baf8-ef2b-4121-8cf7-417be36f64ba",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "bf14d827-c5e4-461b-91fd-b9da93d61d9a",
+                "route": "a10802ce-2b6e-4131-8e46-fc048e0e39e7",
                 "title": "IBM QRadar: Delete Table Element",
                 "resources": [
                   "alerts"
@@ -1782,7 +1782,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "0d672226-c63d-4b50-af7b-ac5776d5e1c8",
+              "uuid": "ead5fa83-2589-48d7-9f6a-f5161dab9876",
               "@type": "WorkflowStep",
               "name": "Delete Table Element",
               "description": null,
@@ -1815,19 +1815,19 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "a17908d9-b4cf-4617-980f-f6c1e5cb02d9",
+              "uuid": "624e7857-fd86-423c-949b-3bd72332cbb0",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Delete Table Element",
-              "sourceStep": "/api/3/workflow_steps/7c300ea3-f5ee-45b3-9fec-02d4495e8baf",
-              "targetStep": "/api/3/workflow_steps/0d672226-c63d-4b50-af7b-ac5776d5e1c8"
+              "sourceStep": "/api/3/workflow_steps/5f16baf8-ef2b-4121-8cf7-417be36f64ba",
+              "targetStep": "/api/3/workflow_steps/ead5fa83-2589-48d7-9f6a-f5161dab9876"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "5d74dde4-8d88-49ac-9bd3-fef2636892a5",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "d91021d1-4fba-4465-980b-079a8cdba02f",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves a list of offenses from the QRadar server based on the filter string and start datetime that you have specified.",
           "name": "Fetch Offenses from QRadar",
@@ -1840,16 +1840,16 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/25da3e71-41d0-4ebb-89d7-ccbbf65a67e2",
+          "triggerStep": "/api/3/workflow_steps/e7365391-12ad-42f8-a69a-2123e1609ce6",
           "steps": [
             {
-              "uuid": "25da3e71-41d0-4ebb-89d7-ccbbf65a67e2",
+              "uuid": "e7365391-12ad-42f8-a69a-2123e1609ce6",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "cc0db9d7-b9dd-44a0-9d8a-bfbf108c9484",
+                "route": "267fd0bf-cad4-45a3-9bd1-d63c25d0656b",
                 "title": "IBM QRadar: Fetch Offenses from QRadar",
                 "resources": [
                   "alerts"
@@ -1869,7 +1869,7 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "c6790d0f-e6c9-4796-85d0-67462e3c4ccd",
+              "uuid": "e3c5db7f-b085-4278-ae20-b4f243838a51",
               "@type": "WorkflowStep",
               "name": "Fetch Offenses from QRadar",
               "description": null,
@@ -1896,22 +1896,22 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "2e445851-e959-4c9e-8af3-327586242de9",
+              "uuid": "970d8a5d-9bdb-420c-b152-4895420ee351",
               "label": null,
               "isExecuted": false,
               "name": "Start-> Fetch Offenses from QRadar",
-              "sourceStep": "/api/3/workflow_steps/25da3e71-41d0-4ebb-89d7-ccbbf65a67e2",
-              "targetStep": "/api/3/workflow_steps/c6790d0f-e6c9-4796-85d0-67462e3c4ccd"
+              "sourceStep": "/api/3/workflow_steps/e7365391-12ad-42f8-a69a-2123e1609ce6",
+              "targetStep": "/api/3/workflow_steps/e3c5db7f-b085-4278-ae20-b4f243838a51"
             }
           ]
         },
         {
           "@type": "Workflow",
-          "uuid": "1dd7857f-d9c5-459a-bba1-c4e726422992",
-          "collection": "/api/3/workflow_collections/fcec4c33-b791-4e17-919f-e8657549c3d6",
+          "uuid": "af0c3dc0-f96c-473d-9225-edfe40fa9c4c",
+          "collection": "/api/3/workflow_collections/f20c3d65-18c3-4b96-8d2d-e0ed22bd8021",
           "triggerLimit": null,
           "description": "Retrieves the MITRE mapping details associated with a QRadar offense from the QRadar server, based on the specified Offense ID.",
-          "name": "Get Mitre Mapping Related to an Offense",
+          "name": "Get Mitre Mapping Related To Offense",
           "tag": "#IBM QRadar",
           "recordTags": [
             "qradar"
@@ -1921,17 +1921,17 @@
           "singleRecordExecution": false,
           "parameters": [],
           "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/6e10b852-8ba0-4a23-b300-607c11a9f2bc",
+          "triggerStep": "/api/3/workflow_steps/dec04227-477c-4c15-bdb5-3f983c95873d",
           "steps": [
             {
-              "uuid": "6e10b852-8ba0-4a23-b300-607c11a9f2bc",
+              "uuid": "dec04227-477c-4c15-bdb5-3f983c95873d",
               "@type": "WorkflowStep",
               "name": "Start",
               "description": null,
               "status": null,
               "arguments": {
-                "route": "6a3fbc6d-1a76-47fb-b638-d47776c5c782",
-                "title": "IBM QRadar: Get Mitre Mapping Related to an Offense",
+                "route": "77f1a163-3a72-44c6-ac0d-37818751ed7b",
+                "title": "IBM QRadar: Get Mitre Mapping Related To Offense",
                 "resources": [
                   "alerts"
                 ],
@@ -1950,9 +1950,9 @@
               "stepType": "/api/3/workflow_step_types/f414d039-bb0d-4e59-9c39-a8f1e880b18a"
             },
             {
-              "uuid": "d0a9b236-b968-4ae0-809c-44d61e26bc62",
+              "uuid": "efd48020-b810-424d-92df-22fbdb3af46b",
               "@type": "WorkflowStep",
-              "name": "Get Mitre Mapping Related to an Offense",
+              "name": "Get Mitre Mapping Related To Offense",
               "description": null,
               "status": null,
               "arguments": {
@@ -1962,7 +1962,7 @@
                 "version": "1.6.3",
                 "connector": "qradar",
                 "operation": "get_mitre_mapping_related_to_an_offense",
-                "operationTitle": "Get Mitre Mapping Related to an Offense",
+                "operationTitle": "Get Mitre Mapping Related To Offense",
                 "step_variables": {
                   "output_data": "{{vars.result}}"
                 }
@@ -1975,12 +1975,12 @@
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "1e1a2451-a3f6-4d0e-a270-fda76c7011f2",
+              "uuid": "72eff696-3093-45c0-af93-0b9756627ffc",
               "label": null,
               "isExecuted": false,
-              "name": "Start-> Get Mitre Mapping Related to an Offense",
-              "sourceStep": "/api/3/workflow_steps/6e10b852-8ba0-4a23-b300-607c11a9f2bc",
-              "targetStep": "/api/3/workflow_steps/d0a9b236-b968-4ae0-809c-44d61e26bc62"
+              "name": "Start-> Get Mitre Mapping Related To Offense",
+              "sourceStep": "/api/3/workflow_steps/dec04227-477c-4c15-bdb5-3f983c95873d",
+              "targetStep": "/api/3/workflow_steps/efd48020-b810-424d-92df-22fbdb3af46b"
             }
           ]
         }


### PR DESCRIPTION
We have a requirement to retrieve MITRE details for QRadar offenses.
Currently, we have specific endpoints available to collect these MITRE details; however, the existing connector is not functioning as expected because it automatically adds the /api prefix to the endpoint.

To address this, I have implemented a new action named get_mitre_mapping_related_to_an_offense to fetch the MITRE details.